### PR TITLE
Allow (+test) on older versions of Julia + fix Unitful version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,8 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
+  - julia_version: 1.0
+  - julia_version: 1.1
   - julia_version: 1.2
   - julia_version: nightly
 platform:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 julia:
+  - 1.0
+  - 1.1
   - 1.2
   - nightly
 matrix:

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,8 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-julia = "1.2"
+julia = "1.0"
+Unitful = ">= 0.16.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Tests seem to pass on julia-1.0 without any code changes, so it's
nice to declare support for that and julia 1.1.

The form of Unitful.ustrip here has only existed since Unitful-0.15.0
and there was an associated bug for that fixed in 0.16.0.
(This is a bug in the declared dependencies for `UnitfulRecipes-0.1.0`
as well, which arguably should be fixed in the registry.)