### PR TITLE
Add osx and windows back in travis CI (test osx for docs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: julia
 os:
   - linux
+  - osx
+  - windows
 julia:
   - 1.0
   - 1.3
@@ -15,7 +17,7 @@ jobs:
   include:
     - stage: "Documentation"
       julia: 1.3
-      os: linux
+      os: osx
       script: julia --project=docs --color=yes -e '
           using Pkg;
           Pkg.develop(PackageSpec(path=pwd()));


### PR DESCRIPTION
Just adding back osx and windows in travis CI.

I also realized that I did not see the cropping issue when deploying the docs locally on OSX, so I changed the OS for the docs to OSX to try it out.