### PR TITLE
Inset feature

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Jan Weidner"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -27,6 +27,17 @@ plot(y)
 y2 = 100randn(10)*u"g"
 plot!(y2)
 
+
+# UnitfulRecipes will not allow you to plot with different unit-dimensions, so
+# ```julia
+# plot!(rand(10)*u"m")
+# ```
+# won't work here.
+#
+# But you can add inset subplots with different axes that have different dimensions
+
+plot!(rand(10)*u"m", inset=bbox(0.5, 0.5, 0.3, 0.3), subplot=2)
+
 # ## Axis label
 
 # If you specify an axis label, the unit will be appended to it.

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -21,8 +21,9 @@ function fixaxis!(attr, x, axisletter)
     axis = Symbol(axisletter, :axis)       # xaxis, yaxis, zaxis
     # Get the unit
     u = pop!(attr, axisunit, unit(eltype(x)))
-    if length(attr[:plot_object].subplots) > 0
-        label = attr[:plot_object][end][axis][:guide]
+    sp = get(attr, :subplot, 1)
+    if sp ≤ length(attr[:plot_object])
+        label = attr[:plot_object][sp][axis][:guide]
         if label isa UnitfulString
             u = label.unit
         end

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -21,6 +21,7 @@ function fixaxis!(attr, x, axisletter)
     axis = Symbol(axisletter, :axis)       # xaxis, yaxis, zaxis
     # Get the unit
     u = pop!(attr, axisunit, unit(eltype(x)))
+    # If the subplot already exists, get unit from its axis label
     sp = get(attr, :subplot, 1)
     if sp ≤ length(attr[:plot_object])
         label = attr[:plot_object][sp][axis][:guide]
@@ -70,15 +71,13 @@ end
 @recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Quantity}, T2<:AVec{<:Quantity}}
     x, y, f.(x',y)
 end
-#@recipe f(xs::V, ys::UV, fun::Function) = recipe!(plotattributes, xs, ys, fun.(xs',ys))
-#@recipe f(xs::UV, ys::V, fun::Function) = recipe!(plotattributes, xs, ys, fun.(xs',ys))
-#
 
 
-#==============
-Attibute fixing
-==============#
+#===============
+Attribute fixing
+===============#
 
+# Markers / lines
 function fixmarkercolor!(attr)
     u = ustripattribute!(attr, :marker_z)
     fixlims!(attr, :clims, u)
@@ -86,6 +85,8 @@ function fixmarkercolor!(attr)
 end
 fixmarkersize!(attr) = ustripattribute!(attr, :markersize)
 fixlinecolor!(attr) = ustripattribute!(attr, :line_z)
+
+# Lims
 function fixlims!(attr, key, u)
     if haskey(attr, key)
         lims = attr[key]
@@ -95,7 +96,7 @@ function fixlims!(attr, key, u)
     end
 end
 
-# strip unit from attribute
+# strip unit from attribute[key]
 function ustripattribute!(attr, key)
     if haskey(attr, key)
         v = attr[key]
@@ -108,9 +109,9 @@ function ustripattribute!(attr, key)
 end
 
 
-#===========
-String stuff
-===========#
+#=======================================
+Label string containing unit information
+=======================================#
 
 abstract type AbstractProtectedString <: AbstractString end
 struct ProtectedString <: AbstractProtectedString
@@ -146,9 +147,9 @@ macro P_str(s)
 end
 
 
-#=============
-label modifier
-=============#
+#=====================================
+Append unit to labels when appropriate
+=====================================#
 
 function append_unit_if_needed!(attr, key, u::Unitful.Units)
     label = get(attr, key, nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,13 @@ using Test, Unitful, Plots
 using Unitful: m, s, cm, DimensionError
 using UnitfulRecipes
 
-xguide(plt) = plt.subplots[end].attr[:xaxis].plotattributes[:guide]
-yguide(plt) = plt.subplots[end].attr[:yaxis].plotattributes[:guide]
-zguide(plt) = plt.subplots[end].attr[:zaxis].plotattributes[:guide]
-xseries(plt) = plt.series_list[end].plotattributes[:x]
-yseries(plt) = plt.series_list[end].plotattributes[:y]
-zseries(plt) = plt.series_list[end].plotattributes[:z]
+# Some helper functions to access the subplot labels and the series inside each test plot
+xguide(plt, idx=length(plt.subplots)) = plt.subplots[idx].attr[:xaxis].plotattributes[:guide]
+yguide(plt, idx=length(plt.subplots)) = plt.subplots[idx].attr[:yaxis].plotattributes[:guide]
+zguide(plt, idx=length(plt.subplots)) = plt.subplots[idx].attr[:zaxis].plotattributes[:guide]
+xseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:x]
+yseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:y]
+zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:z]
 
 @testset "plot(y)" begin
     y = rand(3)m
@@ -163,3 +164,12 @@ end
     @test yseries(plt) ≈ ustrip.(x2) / 100
     @test_throws DimensionError plot!(plt, x3) # can't place seconds on top of meters!
 end 
+
+@testset "Inset subplots" begin
+    x1 = rand(10) * u"m"
+    x2 = rand(10) * u"s"
+    plt = plot(x1)
+    plt = plot!(x2, inset=bbox(0.5, 0.5, 0.3, 0.3), subplot=2)
+    @test yguide(plt,1) == "m"
+    @test yguide(plt,2) == "s"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,6 +68,26 @@ end
     end
 end
 
+@testset "With functions" begin
+    x, y = randn(3), randn(3)
+    @testset "plot(f, x) / plot(x, f)" begin
+        f(x) = x^2
+        @test plot(  f, x*m) isa Plots.Plot
+        @test plot(x*m,   f) isa Plots.Plot
+        g(x) = x*m # If the unit comes from the function only then it throws
+        @test_throws DimensionError plot(x, g) isa Plots.Plot
+        @test_throws DimensionError plot(g, x) isa Plots.Plot
+    end
+    @testset "plot(x, y, f)" begin
+        f(x,y) = x*y
+        @test plot(x*m, y*s, f) isa Plots.Plot
+        @test plot(x*m,   y, f) isa Plots.Plot
+        @test plot(  x, y*s, f) isa Plots.Plot
+        g(x,y) = x*y*m # If the unit comes from the function only then it throws
+        @test_throws DimensionError plot(x, y, g) isa Plots.Plot
+    end
+end
+
 @testset "Moar plots" begin
     @testset "data as $dtype" for dtype in [:Vectors, :Matrices, Symbol("Vectors of vectors")]
         if dtype == :Vectors
@@ -78,14 +98,12 @@ end
             x, y, z = [rand(10), rand(20)], [rand(10), rand(20)], [rand(10), rand(20)]
         end
 
-
         @testset "One array" begin
             @test plot(x*m)                    isa Plots.Plot
             @test plot(x*m, ylabel="x")        isa Plots.Plot
             @test plot(x*m, ylims=(-1,1))      isa Plots.Plot
             @test plot(x*m, ylims=(-1,1) .* m) isa Plots.Plot
-            @test plot(x*m, yunit=u"km") isa Plots.Plot
-            @test plot(x -> x^2, x*m)          isa Plots.Plot
+            @test plot(x*m, yunit=u"km")       isa Plots.Plot
         end
 
         @testset "Two arrays" begin
@@ -151,7 +169,6 @@ end
         y = rand(10)*u"m"
         @test plot(y, label=P"meters") isa Plots.Plot
     end
-
 end
 
 @testset "Comparing apples and oranges" begin
@@ -163,7 +180,7 @@ end
     @test yguide(plt) == "m"
     @test yseries(plt) ≈ ustrip.(x2) / 100
     @test_throws DimensionError plot!(plt, x3) # can't place seconds on top of meters!
-end 
+end
 
 @testset "Inset subplots" begin
     x1 = rand(10) * u"m"


### PR DESCRIPTION
Allow for inset subplots with different unit-dimensions.

Current behavior when doing 
```julia
x1 = rand(10) * u"m"
x2 = rand(10) * u"s"
plt = plot(x1)
plt = plot!(x2, inset=bbox(0.5, 0.5, 0.3, 0.3), subplot=2)
```

was throwing an error because it was unhappy that the first plot had a different unit-dimension to the second one. I think this PR fixes this, by checking the unit of the axis label of the *current* subplot (instead of  *last* subplot) in `plot_attributes`.