### PR TITLE
Fix String -> AbstractString

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/2_Plots.jl
+++ b/docs/lit/examples/2_Plots.jl
@@ -39,7 +39,7 @@ y = rand(20, 3)*u"W"
 x = (1:size(y,1))*u"Hz"
 plot(x, y, xlabel="XLABEL", xlims=(-5, 30), xflip=true, xticks=0:2:20, background_color=RGB(0.2, 0.2, 0.2), leg=false)
 hline!(mean(y, dims=1) + rand(1, 3)*u"W", line=(4, :dash, 0.6, [:lightgreen :green :darkgreen]))
-vline!([5, 10]*u"W") # this is a current Plots v1.0.3 bug. Should be Hz
+vline!([5, 10]*u"Hz")
 title!("TITLE")
 yaxis!("YLABEL", :log10)
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -114,11 +114,11 @@ Label string containing unit information
 =======================================#
 
 abstract type AbstractProtectedString <: AbstractString end
-struct ProtectedString <: AbstractProtectedString
-    content::String
+struct ProtectedString{S} <: AbstractProtectedString
+    content::S
 end
-struct UnitfulString{U} <: AbstractProtectedString
-    content::String
+struct UnitfulString{S,U} <: AbstractProtectedString
+    content::S
     unit::U
 end
 # Minimum required AbstractString interface to work with Plots
@@ -161,9 +161,9 @@ append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing
 function append_unit_if_needed!(attr, key, label::Nothing, u)
     attr[key] = UnitfulString(string(u), u)
 end
-function append_unit_if_needed!(attr, key, label::String, u)
+function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if label ≠ ""
-        attr[key] = UnitfulString(string(label, " (", u, ")"), u)
+        attr[key] = UnitfulString(S(string(label, " (", u, ")")), u)
     end
 end
 


### PR DESCRIPTION
This PR "extends" the types of labels from `String` to `AbstractString`,  so that then one can use, e.g., a `LaTeXString` as a label. See [this recent discourse post](https://discourse.julialang.org/t/uniftulrecipes-and-latexstrings/52247).

With that PR, the following MWE:

```julia
using Unitful, UnitfulRecipes, Plots, LaTeXStrings
pyplot() # this use of LaTeXStrings does not work with the GR backend for me
const a = 1u"m/s^2"
v(t) = a * t
x(t) = a/2 * t^2
t = (0:0.01:100)*u"s"
plot(x.(t), v.(t), xlabel=L"Position $\xi$", ylabel=L"Speed $\sigma$")
```

outputs

<img width="712" alt="Screen Shot 2020-12-23 at 6 43 22 pm" src="https://user-images.githubusercontent.com/4486578/102972161-bcaaae00-454e-11eb-8fe4-c06c976140a8.png">
