### PR TITLE
Fixed GR display bug when units have powers.

### DIFF
--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -164,8 +164,6 @@ end
 function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if label ≠ ""
         attr[key] = UnitfulString(S(string(label, " (", replace(string(u), r"(\d+)" => s"{\1}"), ")")), u)
-        println("Key is $(key) and the value is $(attr[key]).")
-        attr[key]
     end
 end
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -159,11 +159,13 @@ end
 append_unit_if_needed!(attr, key, label::ProtectedString, u) = nothing
 append_unit_if_needed!(attr, key, label::UnitfulString, u) = nothing
 function append_unit_if_needed!(attr, key, label::Nothing, u)
-    attr[key] = UnitfulString(string(u), u)
+    attr[key] = UnitfulString(replace(string(u), r"(\d+)" => s"{\1}"), u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if label ≠ ""
-        attr[key] = UnitfulString(S(string(label, " (", u, ")")), u)
+        attr[key] = UnitfulString(S(string(label, " (", replace(string(u), r"(\d+)" => s"{\1}"), ")")), u)
+        println("Key is $(key) and the value is $(attr[key]).")
+        attr[key]
     end
 end
 


### PR DESCRIPTION
When the units have powers, you need to escape the powers with {...} in
order to have the following text remain in normal script.