### PR TITLE
Add recipes for Unitful xerror/yerror/zerror

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -110,4 +110,14 @@ contour(x, y, z)
 
 contourf(x, y, z)
 
+# ## Error bars
+
+# For example, you can use the `yerror` keyword argument with units,
+# which will be converted to the units of `y` and plot your errorbars:
+
+using Unitful: GeV, MeV, c
+x = (1.0:0.1:10) * GeV/c
+y = @. (2 + sin(x / (GeV/c))) * 0.4GeV/c^2 # a sine to make it pretty
+yerror = 10.9MeV/c^2 * exp.(randn(length(x))) # some noise for pretty again
+plot(x, y; yerror, title="My unitful data with yerror bars", lab="")
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -17,6 +17,7 @@ function fixaxis!(attr, x, axisletter)
     # Attribute keys
     axislabel = Symbol(axisletter, :guide) # xguide, yguide, zguide
     axislims = Symbol(axisletter, :lims)   # xlims, ylims, zlims
+    err = Symbol(axisletter, :error)       # xerror, yerror, zerror
     axisunit = Symbol(axisletter, :unit)   # xunit, yunit, zunit
     axis = Symbol(axisletter, :axis)       # xaxis, yaxis, zaxis
     # Get the unit
@@ -31,7 +32,8 @@ function fixaxis!(attr, x, axisletter)
     end
     # Fix the attributes: labels, lims, marker/line stuff, etc.
     append_unit_if_needed!(attr, axislabel, u)
-    fixlims!(attr, axislims, u)
+    ustripattribute!(attr, axislims, u)
+    ustripattribute!(attr, err, u)
     fixmarkercolor!(attr)
     fixmarkersize!(attr)
     fixlinecolor!(attr)
@@ -80,21 +82,11 @@ Attribute fixing
 # Markers / lines
 function fixmarkercolor!(attr)
     u = ustripattribute!(attr, :marker_z)
-    fixlims!(attr, :clims, u)
+    ustripattribute!(attr, :clims, u)
     u == Unitful.NoUnits || append_unit_if_needed!(attr, :colorbar_title, u)
 end
 fixmarkersize!(attr) = ustripattribute!(attr, :markersize)
 fixlinecolor!(attr) = ustripattribute!(attr, :line_z)
-
-# Lims
-function fixlims!(attr, key, u)
-    if haskey(attr, key)
-        lims = attr[key]
-        if lims isa NTuple{2, Quantity}
-            attr[key] = ustrip.(u, lims)
-        end
-    end
-end
 
 # strip unit from attribute[key]
 function ustripattribute!(attr, key)
@@ -107,7 +99,15 @@ function ustripattribute!(attr, key)
         return Unitful.NoUnits
     end
 end
-
+# when a unit is suppled as 3rd argument, then use that unit
+function ustripattribute!(attr, key, u)
+    if haskey(attr, key)
+        v = attr[key]
+        if eltype(v) <: Quantity
+            attr[key] = ustrip.(u, v)
+        end
+    end
+end
 
 #=======================================
 Label string containing unit information

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -99,7 +99,7 @@ function ustripattribute!(attr, key)
         return Unitful.NoUnits
     end
 end
-# when a unit is suppled as 3rd argument, then use that unit
+# If supplied, use the unit (optional 3rd argument)
 function ustripattribute!(attr, key, u)
     if haskey(attr, key)
         v = attr[key]
@@ -107,6 +107,7 @@ function ustripattribute!(attr, key, u)
             attr[key] = ustrip.(u, v)
         end
     end
+    u
 end
 
 #=======================================

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -198,3 +198,14 @@ end
     plt = plot(x,y)
     @test yguide(plt,1) == "s"
 end
+
+@testset "Errors" begin
+    x = rand(10) * u"mm"
+    ex = rand(10) * u"μm"
+    y = rand(10) * u"s"
+    ey = rand(10) * u"ms"
+    plt =  plot(x, y, xerr=ex, yerr=ey)
+    @test plt isa Plots.Plot
+    @test xguide(plt) == "mm"
+    @test yguide(plt) == "s"
+end


### PR DESCRIPTION
Fixes #42 

Output of this MWE from #42 

```julia
using Unitful, Plots, UnitfulRecipes
momenta = [p*1u"GeV/c" for p in 1.0:0.1:10]
masses = [139.57039u"MeV/c^2"]
piMass = ones(length(momenta))*masses[1]
piErr=[10.882833439073304u"MeV/c^2" for p in momenta]
yerr=piErr
plot(momenta, [piMass], yerr=yerr, label=["pion"])
```

with this PR (tested on Julia 1.6)

<img width="712" alt="Screen Shot 2021-03-02 at 10 34 09 am" src="https://user-images.githubusercontent.com/4486578/109573267-d534d700-7b42-11eb-9c01-656a5b4d5481.png">
