### PR TITLE
Other formats beyond "label (unit)"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -52,7 +52,7 @@ plot(y, ylabel=P"mass in kilograms")
 
 plot(y, ylabel="")
 
-# ### Surround
+# ### Unit formatting
 
 # If you prefer some other formatting over the round parentheses, you can
 # supply a keyword `unitformat`, which can be a number of different things: A
@@ -181,4 +181,3 @@ x = (1.0:0.1:10) * GeV/c
 y = @. (2 + sin(x / (GeV/c))) * 0.4GeV/c^2 # a sine to make it pretty
 yerror = 10.9MeV/c^2 * exp.(randn(length(x))) # some noise for pretty again
 plot(x, y; yerror, title="My unitful data with yerror bars", lab="")
-

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -55,21 +55,63 @@ plot(y, ylabel="")
 # ### Surround
 
 # If you prefer some other formatting over the round parentheses, you can
-# supply a keyword `surround`, which can be a number of different things:
-# `:round`,`:square`,`:curly` and `:slash` do what you might expect.
-# `:slashround` and the likes will combine them. `:verbose` will insert an " in
-# units of " between the label and the unit. `nothing` will remove the
-# parentheses.  For more customizatbility, a character, a string or a `Tuple`
-# of characters or strings can be supplied, which will be inserted between the
-# label and the unit, around the unit or before, between and after, depending
-# on the length of the tuple.
+# supply a keyword `surround`, which can be a number of different things: A
+# `Symbol` representing a standard case (see example below), a `Char`, a
+# `String`, or a `Tuple` (of `Char`s or `String`s), which will be inserted
+# arround the label and unit depending on the length of the tuple.
 
-plot(y,ylabel="mass",surround=:square)
+plot(y, ylabel="mass", surround=:square)
 
 # For *extreme* customizability, you can also supply a function that turns two
 # arguments (label, unit) into a string.
 
-plot(y,ylabel="mass",surround=(l,u)->string("\$\\frac{",l,"}{\\mathrm{",u,"}}\$"))
+plot(y, ylabel="mass", surround=(l, u)->string("\$\\frac{", l, "}{\\mathrm{", u, "}}\$"))
+
+# A complete list of options:
+labelformatter(l, u) = string(u, ' ', l)
+surrounds = [
+             [
+              :round,
+              :square,
+              :curly,
+              :angle,
+              :slash,
+              :slashround,
+              :slashsquare,
+              :slashcurly,
+              :slashangle,
+              :verbose,
+             ],
+             [
+              ", in ",
+              (", in (", ")"),
+              ("[", "] = (", ")"),
+              ':',
+              ('$', '$'),
+              (':', ':', ':'),
+             ],
+             [
+              nothing,
+              labelformatter,
+              false,
+              true,
+             ],
+            ]
+plot([
+      plot([
+            plot(y, 1:10, xlabel="mass", title=repr(s),
+                 surround=s) for s in surrounds[1]
+           ]..., layout=(2, 5)),
+      plot([
+            plot(y, 1:10, xlabel="mass", title=repr(s),
+                 surround=s) for s in surrounds[2]
+           ]..., layout=(2, 3)),
+      plot([
+            plot(y, 1:10, xlabel="mass", title=repr(s),
+                 surround=s) for s in surrounds[3]
+           ]..., layout=(1, 4)),
+     ]..., layout=(3, 1), size=(1200, 800),
+    )
 
 # ## Axis unit
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -58,13 +58,16 @@ plot(y, ylabel="")
 # `:round`,`:square`,`:curly` and `:slash` do what you might expect.
 # `:slashround` and the likes will combine them. `:verbose` will insert an " in
 # units of " between the label and the unit. `nothing` will remove the
-# parentheses.  For more customizatbility, a character, a string a `Tuple` of
-# characters or strings can be supplied, which will be inserted between the
+# parentheses.  For more customizatbility, a character, a string or a `Tuple`
+# of characters or strings can be supplied, which will be inserted between the
 # label and the unit, around the unit or before, between and after, depending
-# on the length of the tuple. For *extreme* customizability, you can also
-# supply a function that turns two arguments (label, unit) into a string.
+# on the length of the tuple.
 
 plot(y,ylabel="mass",surround=:square)
+
+# For *extreme* customizability, you can also supply a function that turns two
+# arguments (label, unit) into a string.
+
 plot(y,ylabel="mass",surround=(l,u)->string("\$\\frac{",l,"}{\\mathrm{",u,"}}\$"))
 
 # ## Axis unit

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -55,21 +55,21 @@ plot(y, ylabel="")
 # ### Surround
 
 # If you prefer some other formatting over the round parentheses, you can
-# supply a keyword `surround`, which can be a number of different things: A
+# supply a keyword `unitformat`, which can be a number of different things: A
 # `Symbol` representing a standard case (see example below), a `Char`, a
 # `String`, or a `Tuple` (of `Char`s or `String`s), which will be inserted
 # arround the label and unit depending on the length of the tuple.
 
-plot(y, ylabel="mass", surround=:square)
+plot(y, ylabel="mass", unitformat=:square)
 
 # For *extreme* customizability, you can also supply a function that turns two
 # arguments (label, unit) into a string.
 
-plot(y, ylabel="mass", surround=(l, u)->string("\$\\frac{", l, "}{\\mathrm{", u, "}}\$"))
+plot(y, ylabel="mass", unitformat=(l, u)->string("\$\\frac{", l, "}{\\mathrm{", u, "}}\$"))
 
 # A complete list of options:
 labelformatter(l, u) = string(u, ' ', l)
-surrounds = [
+unitformats = [
              [
               :round,
               :square,
@@ -100,15 +100,15 @@ surrounds = [
 plot([
       plot([
             plot(y, 1:10, xlabel="mass", title=repr(s),
-                 surround=s) for s in surrounds[1]
+                 unitformat=s) for s in unitformats[1]
            ]..., layout=(2, 5)),
       plot([
             plot(y, 1:10, xlabel="mass", title=repr(s),
-                 surround=s) for s in surrounds[2]
+                 unitformat=s) for s in unitformats[2]
            ]..., layout=(2, 3)),
       plot([
             plot(y, 1:10, xlabel="mass", title=repr(s),
-                 surround=s) for s in surrounds[3]
+                 unitformat=s) for s in unitformats[3]
            ]..., layout=(1, 4)),
      ]..., layout=(3, 1), size=(1200, 800),
     )

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -92,17 +92,17 @@ plot(y, yunit=u"g")
 
 # Setting the axis limits can be done with units
 
-plot(y, ylims=(-1000u"g", 2000u"g"))
+plot(y, ylims=(-1000u"g",2000u"g"))
 
 # or without
 
-plot(y, ylims=(-1, 2))
+plot(y, ylims=(-1,2))
 
 # ## Multiple series
 
 # You can plot multiple series as 2D arrays
 
-x, y = rand(10, 3)*u"m", rand(10, 3)*u"g"
+x, y = rand(10,3)*u"m", rand(10,3)*u"g"
 plot(x, y)
 
 # Or vectors of vectors (of potnetially different lengths)
@@ -122,7 +122,7 @@ plot(x, y, z)
 
 # You can do scatter plots
 
-scatter(x, y, zcolor=z, clims=(5, 20).*unit(eltype(z)))
+scatter(x, y, zcolor=z, clims=(5,20).*unit(eltype(z)))
 
 # and 3D scatter plots too
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -1,4 +1,5 @@
-#--------------------------------------------------------- # # [Simple Examples](@id 1_Examples)
+#---------------------------------------------------------
+# # [Simple Examples](@id 1_Examples)
 #---------------------------------------------------------
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/notebooks/1_Examples.ipynb)

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -1,5 +1,4 @@
-#---------------------------------------------------------
-# # [Simple Examples](@id 1_Examples)
+#--------------------------------------------------------- # # [Simple Examples](@id 1_Examples)
 #---------------------------------------------------------
 
 #md # [![](https://mybinder.org/badge_logo.svg)](@__BINDER_ROOT_URL__/notebooks/1_Examples.ipynb)
@@ -51,6 +50,22 @@ plot(y, ylabel=P"mass in kilograms")
 # Just like with the `label` keyword for legends, no axis label is added if you specify the axis label to be an empty string.
 
 plot(y, ylabel="")
+
+# ### Surround
+
+# If you prefer some other formatting over the round parentheses, you can
+# supply a keyword `surround`, which can be a number of different things:
+# `:round`,`:square`,`:curly` and `:slash` do what you might expect.
+# `:slashround` and the likes will combine them. `:verbose` will insert an " in
+# units of " between the label and the unit. `nothing` will remove the
+# parentheses.  For more customizatbility, a character, a string a `Tuple` of
+# characters or strings can be supplied, which will be inserted between the
+# label and the unit, around the unit or before, between and after, depending
+# on the length of the tuple. For *extreme* customizability, you can also
+# supply a function that turns two arguments (label, unit) into a string.
+
+plot(y,ylabel="mass",surround=:square)
+plot(y,ylabel="mass",surround=(l,u)->string("\$\\frac{",l,"}{\\mathrm{",u,"}}\$"))
 
 # ## Axis unit
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -55,63 +55,32 @@ plot(y, ylabel="")
 # ### Unit formatting
 
 # If you prefer some other formatting over the round parentheses, you can
-# supply a keyword `unitformat`, which can be a number of different things: A
-# `Symbol` representing a standard case (see example below), a `Char`, a
-# `String`, or a `Tuple` (of `Char`s or `String`s), which will be inserted
-# arround the label and unit depending on the length of the tuple.
+# supply a keyword `unitformat`, which can be a number of different things:
 
-plot(y, ylabel="mass", unitformat=:square)
+# `unitformat` can be a boolean or `nothing`:
+
+plot([plot(y, ylab="mass", title=repr(s), unitformat=s) for s in (nothing, true, false)]...)
+
+# `unitformat` can be one of a number of predefined symbols, defined in
+
+URsymbols = keys(UnitfulRecipes.UNIT_FORMATS)
+
+# which correspond to these unit formats:
+
+plot([plot(y, ylab="mass", title=repr(s), unitformat=s) for s in URsymbols]...)
+
+# `unitformat` can also be a `Char`, a `String`, or a `Tuple` (of `Char`s or
+# `String`s), which will be inserted around the label and unit depending on the
+# length of the tuple:
+
+URtuples = [", in ", (", in (", ")"), ("[", "] = (", ")"), ':', ('$', '$'), (':', ':', ':')]
+plot([plot(y, ylab="mass", title=repr(s), unitformat=s) for s in URtuples]...)
 
 # For *extreme* customizability, you can also supply a function that turns two
-# arguments (label, unit) into a string.
+# arguments (label, unit) into a string:
 
-plot(y, ylabel="mass", unitformat=(l, u)->string("\$\\frac{", l, "}{\\mathrm{", u, "}}\$"))
-
-# A complete list of options:
-labelformatter(l, u) = string(u, ' ', l)
-unitformats = [
-             [
-              :round,
-              :square,
-              :curly,
-              :angle,
-              :slash,
-              :slashround,
-              :slashsquare,
-              :slashcurly,
-              :slashangle,
-              :verbose,
-             ],
-             [
-              ", in ",
-              (", in (", ")"),
-              ("[", "] = (", ")"),
-              ':',
-              ('$', '$'),
-              (':', ':', ':'),
-             ],
-             [
-              nothing,
-              labelformatter,
-              false,
-              true,
-             ],
-            ]
-plot([
-      plot([
-            plot(y, 1:10, xlabel="mass", title=repr(s),
-                 unitformat=s) for s in unitformats[1]
-           ]..., layout=(2, 5)),
-      plot([
-            plot(y, 1:10, xlabel="mass", title=repr(s),
-                 unitformat=s) for s in unitformats[2]
-           ]..., layout=(2, 3)),
-      plot([
-            plot(y, 1:10, xlabel="mass", title=repr(s),
-                 unitformat=s) for s in unitformats[3]
-           ]..., layout=(1, 4)),
-     ]..., layout=(3, 1), size=(1200, 800),
-    )
+formatter(l, u) = string("\$\\frac{\\textrm{", l, "}}{\\mathrm{", u, "}}\$")
+plot(y, ylab="mass", unitformat=formatter)
 
 # ## Axis unit
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -123,17 +123,17 @@ plot(y, yunit=u"g")
 
 # Setting the axis limits can be done with units
 
-plot(y, ylims=(-1000u"g",2000u"g"))
+plot(y, ylims=(-1000u"g", 2000u"g"))
 
 # or without
 
-plot(y, ylims=(-1,2))
+plot(y, ylims=(-1, 2))
 
 # ## Multiple series
 
 # You can plot multiple series as 2D arrays
 
-x, y = rand(10,3)*u"m", rand(10,3)*u"g"
+x, y = rand(10, 3)*u"m", rand(10, 3)*u"g"
 plot(x, y)
 
 # Or vectors of vectors (of potnetially different lengths)
@@ -153,7 +153,7 @@ plot(x, y, z)
 
 # You can do scatter plots
 
-scatter(x, y, zcolor=z, clims=(5,20).*unit(eltype(z)))
+scatter(x, y, zcolor=z, clims=(5, 20).*unit(eltype(z)))
 
 # and 3D scatter plots too
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -8,7 +8,7 @@ export @P_str
 Main recipe
 ==========#
 
-@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing, <:Quantity}}
     axisletter = plotattributes[:letter]   # x, y, or z
     fixaxis!(plotattributes, x, axisletter)
 end
@@ -43,7 +43,7 @@ end
 
 # Recipe for (x::AVec, y::AVec, z::Surface) types
 const AVec = AbstractVector
-const AMat{T} = AbstractArray{T,2} where T
+const AMat{T} = AbstractArray{T, 2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
     z = fixaxis!(plotattributes, z, :z)
@@ -52,26 +52,26 @@ const AMat{T} = AbstractArray{T,2} where T
 end
 
 # Recipe for vectors of vectors
-@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing, <:Quantity}}}
     axisletter = plotattributes[:letter]   # x, y, or z
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
 
 # Recipes for functions
-@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing, <:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
-    x, y, f.(x',y)
+@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
+    x, y, f.(x', y)
 end
-@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
-    x, y, f.(x',y)
+@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
+    x, y, f.(x', y)
 end
-@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
-    x, y, f.(x',y)
+@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing, <:Quantity}}, T2<:AVec{<:Union{Missing, <:Quantity}}}
+    x, y, f.(x', y)
 end
 
 
@@ -118,7 +118,7 @@ abstract type AbstractProtectedString <: AbstractString end
 struct ProtectedString{S} <: AbstractProtectedString
     content::S
 end
-struct UnitfulString{S,U} <: AbstractProtectedString
+struct UnitfulString{S, U} <: AbstractProtectedString
     content::S
     unit::U
 end
@@ -164,33 +164,33 @@ function append_unit_if_needed!(attr, key, label::Nothing, u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if !isempty(label)
-        attr[key] = UnitfulString(S(surround(label,u, get(attr,:surround,:round))), u)
+        attr[key] = UnitfulString(S(surround(label, u, get(attr, :surround, :round))), u)
     end
 end
 
 #=============================================
 Surround unit string with specified delimiters
 =============================================#
-surround(l,u,f::Nothing) = string(l,' ',u)
-surround(l,u,f::Function) = f(l,u)
-surround(l,u,f::AbstractString) = string(l,f,u)
-surround(l,u,f::NTuple{2,<:AbstractString}) = string(l,f[1],u,f[2])
-surround(l,u,f::NTuple{3,<:AbstractString}) = string(f[1],l,f[2],u,f[3])
-surround(l,u,f::Char) = string(l,' ',f,' ',u)
-surround(l,u,f::NTuple{2,Char}) = string(l,' ',f[1],u,f[2])
-surround(l,u,f::NTuple{3,Char}) = string(f[1],l,' ',f[2],u,f[3])
-surround(l,u,f::Bool) = f ? surround(l,u,:round) : surround(l,u,nothing)
-function surround(l,u,f::Symbol)
-    f===:round && return surround(l,u,('(',')'))
-    f===:square && return surround(l,u,('[',']'))
-    f===:curly && return surround(l,u,('{','}'))
-    f===:angle && return surround(l,u,('<','>'))
-    f===:slash && return surround(l,u,'/')
-    f===:slashround && return surround(l,u,(" / (",")"))
-    f===:slashsquare && return surround(l,u,(" / [","]"))
-    f===:slashcurly && return surround(l,u,(" / {","}"))
-    f===:slashangle && return surround(l,u,(" / <",">"))
-    f===:verbose && return surround(l,u," in units of ")
+surround(l, u, f::Nothing) = string(l, ' ', u)
+surround(l, u, f::Function) = f(l, u)
+surround(l, u, f::AbstractString) = string(l, f, u)
+surround(l, u, f::NTuple{2, <:AbstractString}) = string(l, f[1], u, f[2])
+surround(l, u, f::NTuple{3, <:AbstractString}) = string(f[1], l, f[2], u, f[3])
+surround(l, u, f::Char) = string(l, ' ', f, ' ', u)
+surround(l, u, f::NTuple{2, Char}) = string(l, ' ', f[1], u, f[2])
+surround(l, u, f::NTuple{3, Char}) = string(f[1], l, ' ', f[2], u, f[3])
+surround(l, u, f::Bool) = f ? surround(l, u, :round) : surround(l, u, nothing)
+function surround(l, u, f::Symbol)
+    f===:round && return surround(l, u, ('(', ')'))
+    f===:square && return surround(l, u, ('[', ']'))
+    f===:curly && return surround(l, u, ('{', '}'))
+    f===:angle && return surround(l, u, ('<', '>'))
+    f===:slash && return surround(l, u, '/')
+    f===:slashround && return surround(l, u, (" / (", ")"))
+    f===:slashsquare && return surround(l, u, (" / [", "]"))
+    f===:slashcurly && return surround(l, u, (" / {", "}"))
+    f===:slashangle && return surround(l, u, (" / <", ">"))
+    f===:verbose && return surround(l, u, " in units of ")
 end
 
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -164,34 +164,36 @@ function append_unit_if_needed!(attr, key, label::Nothing, u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if !isempty(label)
-        attr[key] = UnitfulString(S(surround(label, u, get(attr, :surround, :round))), u)
+        attr[key] = UnitfulString(S(format_unit_label(label, u, get(attr, :unitformat, :round))), u)
     end
 end
 
 #=============================================
 Surround unit string with specified delimiters
 =============================================#
-surround(l, u, f::Nothing) = string(l, ' ', u)
-surround(l, u, f::Function) = f(l, u)
-surround(l, u, f::AbstractString) = string(l, f, u)
-surround(l, u, f::NTuple{2, <:AbstractString}) = string(l, f[1], u, f[2])
-surround(l, u, f::NTuple{3, <:AbstractString}) = string(f[1], l, f[2], u, f[3])
-surround(l, u, f::Char) = string(l, ' ', f, ' ', u)
-surround(l, u, f::NTuple{2, Char}) = string(l, ' ', f[1], u, f[2])
-surround(l, u, f::NTuple{3, Char}) = string(f[1], l, ' ', f[2], u, f[3])
-surround(l, u, f::Bool) = f ? surround(l, u, :round) : surround(l, u, nothing)
-function surround(l, u, f::Symbol)
-    f===:round && return surround(l, u, ('(', ')'))
-    f===:square && return surround(l, u, ('[', ']'))
-    f===:curly && return surround(l, u, ('{', '}'))
-    f===:angle && return surround(l, u, ('<', '>'))
-    f===:slash && return surround(l, u, '/')
-    f===:slashround && return surround(l, u, (" / (", ")"))
-    f===:slashsquare && return surround(l, u, (" / [", "]"))
-    f===:slashcurly && return surround(l, u, (" / {", "}"))
-    f===:slashangle && return surround(l, u, (" / <", ">"))
-    f===:verbose && return surround(l, u, " in units of ")
-end
+format_unit_label(l, u, f::Nothing) = string(l, ' ', u)
+format_unit_label(l, u, f::Function) = f(l, u)
+format_unit_label(l, u, f::AbstractString) = string(l, f, u)
+format_unit_label(l, u, f::NTuple{2, <:AbstractString}) = string(l, f[1], u, f[2])
+format_unit_label(l, u, f::NTuple{3, <:AbstractString}) = string(f[1], l, f[2], u, f[3])
+format_unit_label(l, u, f::Char) = string(l, ' ', f, ' ', u)
+format_unit_label(l, u, f::NTuple{2, Char}) = string(l, ' ', f[1], u, f[2])
+format_unit_label(l, u, f::NTuple{3, Char}) = string(f[1], l, ' ', f[2], u, f[3])
+format_unit_label(l, u, f::Bool) = f ? format_unit_label(l, u, :round) : format_unit_label(l, u, nothing)
 
+const UNIT_FORMATS = Dict(
+                          :round => ('(', ')'),
+                          :square => ('[', ']'),
+                          :curly => ('{', '}'),
+                          :angle => ('<', '>'),
+                          :slash => '/',
+                          :slashround => (" / (", ")"),
+                          :slashsquare => (" / [", "]"),
+                          :slashcurly => (" / {", "}"),
+                          :slashangle => (" / <", ">"),
+                          :verbose => " in units of ",
+                         )
+
+format_unit_label(l, u, f::Symbol) = format_unit_label(l,u,UNIT_FORMATS[f])
 
 end # module

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -8,7 +8,7 @@ export @P_str
 Main recipe
 ==========#
 
-@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing, <:Quantity}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
     axisletter = plotattributes[:letter]   # x, y, or z
     fixaxis!(plotattributes, x, axisletter)
 end
@@ -43,7 +43,7 @@ end
 
 # Recipe for (x::AVec, y::AVec, z::Surface) types
 const AVec = AbstractVector
-const AMat{T} = AbstractArray{T, 2} where T
+const AMat{T} = AbstractArray{T,2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
     z = fixaxis!(plotattributes, z, :z)
@@ -52,26 +52,26 @@ const AMat{T} = AbstractArray{T, 2} where T
 end
 
 # Recipe for vectors of vectors
-@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing, <:Quantity}}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
     axisletter = plotattributes[:letter]   # x, y, or z
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
 
 # Recipes for functions
-@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing, <:Quantity}}
+@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
+@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
-    x, y, f.(x', y)
+@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+    x, y, f.(x',y)
 end
-@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing, <:Quantity}}
-    x, y, f.(x', y)
+@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+    x, y, f.(x',y)
 end
-@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing, <:Quantity}}, T2<:AVec{<:Union{Missing, <:Quantity}}}
-    x, y, f.(x', y)
+@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
+    x, y, f.(x',y)
 end
 
 
@@ -118,7 +118,7 @@ abstract type AbstractProtectedString <: AbstractString end
 struct ProtectedString{S} <: AbstractProtectedString
     content::S
 end
-struct UnitfulString{S, U} <: AbstractProtectedString
+struct UnitfulString{S,U} <: AbstractProtectedString
     content::S
     unit::U
 end

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -8,8 +8,7 @@ export @P_str
 Main recipe
 ==========#
 
-@recipe function f(::Type{T}, x::T; surround=:round) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
-    plotattributes[:surround] = surround
+@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
     axisletter = plotattributes[:letter]   # x, y, or z
     fixaxis!(plotattributes, x, axisletter)
 end
@@ -45,8 +44,7 @@ end
 # Recipe for (x::AVec, y::AVec, z::Surface) types
 const AVec = AbstractVector
 const AMat{T} = AbstractArray{T,2} where T
-@recipe function f(x::AVec, y::AVec, z::AMat{T}, surround=:round) where T <: Quantity
-    plotattributes[:surround] = surround
+@recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
     z = fixaxis!(plotattributes, z, :z)
     append_unit_if_needed!(plotattributes, :colorbar_title, u)
@@ -54,31 +52,25 @@ const AMat{T} = AbstractArray{T,2} where T
 end
 
 # Recipe for vectors of vectors
-@recipe function f(::Type{T}, x::T, surround=:round) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
-    plotattributes[:surround] = surround
+@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
     axisletter = plotattributes[:letter]   # x, y, or z
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
 
 # Recipes for functions
-@recipe function f(f::Function, x::T, surround=:round) where T <: AVec{<:Union{Missing,<:Quantity}}
-    plotattributes[:surround] = surround
+@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, f::Function, surround=:round) where T <: AVec{<:Union{Missing,<:Quantity}}
-    plotattributes[:surround] = surround
+@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
-@recipe function f(x::T, y::AVec, f::Function, surround=:round) where T <: AVec{<:Union{Missing,<:Quantity}}
-    plotattributes[:surround] = surround
+@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, y, f.(x',y)
 end
-@recipe function f(x::AVec, y::T, f::Function, surround=:round) where T <: AVec{<:Union{Missing,<:Quantity}}
-    plotattributes[:surround] = surround
+@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, y, f.(x',y)
 end
-@recipe function f(x::T1, y::T2, f::Function, surround=:round) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
-    plotattributes[:surround] = surround
+@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
     x, y, f.(x',y)
 end
 
@@ -172,7 +164,7 @@ function append_unit_if_needed!(attr, key, label::Nothing, u)
 end
 function append_unit_if_needed!(attr, key, label::S, u) where {S <: AbstractString}
     if !isempty(label)
-        attr[key] = UnitfulString(S(surround(label,u, attr[:surround])), u)
+        attr[key] = UnitfulString(S(surround(label,u, get(attr,:surround,:round))), u)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,6 +66,31 @@ end
         @test yguide(plot(x, y, xlabel= "hello", ylabel= "hello")) == "hello (s)"
         @test yguide(plot(x, y, xlabel=P"hello", ylabel=P"hello")) == "hello"
     end
+
+    @testset "surround" begin
+        args = (x,y)
+        kwargs = (:xlabel=>"hello",:ylabel=>"hello")
+        @test yguide(plot(args...;kwargs..., surround=nothing)) == "hello s"
+        @test yguide(plot(args...;kwargs..., surround=(l,u) -> string(u," is the unit of ",l))) == "s is the unit of hello"
+        @test yguide(plot(args...;kwargs..., surround=", dear ")) == "hello, dear s"
+        @test yguide(plot(args...;kwargs..., surround=(", dear "," esq."))) == "hello, dear s esq."
+        @test yguide(plot(args...;kwargs..., surround=("well ",", dear "," esq."))) == "well hello, dear s esq."
+        @test yguide(plot(args...;kwargs..., surround='?')) == "hello ? s"
+        @test yguide(plot(args...;kwargs..., surround=('<','>'))) == "hello <s>"
+        @test yguide(plot(args...;kwargs..., surround=('A','B','C'))) == "Ahello BsC"
+        @test yguide(plot(args...;kwargs..., surround=false)) == "hello s"
+        @test yguide(plot(args...;kwargs..., surround=true)) == "hello (s)"
+        @test yguide(plot(args...;kwargs..., surround=:round)) == "hello (s)"
+        @test yguide(plot(args...;kwargs..., surround=:square)) == "hello [s]"
+        @test yguide(plot(args...;kwargs..., surround=:curly)) == "hello {s}"
+        @test yguide(plot(args...;kwargs..., surround=:angle)) == "hello <s>"
+        @test yguide(plot(args...;kwargs..., surround=:slash)) == "hello / s"
+        @test yguide(plot(args...;kwargs..., surround=:slashround)) == "hello / (s)"
+        @test yguide(plot(args...;kwargs..., surround=:slashsquare)) == "hello / [s]"
+        @test yguide(plot(args...;kwargs..., surround=:slashcurly)) == "hello / {s}"
+        @test yguide(plot(args...;kwargs..., surround=:slashangle)) == "hello / <s>"
+        @test yguide(plot(args...;kwargs..., surround=:verbose)) == "hello in units of s"
+    end
 end
 
 @testset "With functions" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,28 +68,28 @@ end
     end
 
     @testset "surround" begin
-        args = (x,y)
-        kwargs = (:xlabel=>"hello",:ylabel=>"hello")
-        @test yguide(plot(args...;kwargs..., surround=nothing)) == "hello s"
-        @test yguide(plot(args...;kwargs..., surround=(l,u) -> string(u," is the unit of ",l))) == "s is the unit of hello"
-        @test yguide(plot(args...;kwargs..., surround=", dear ")) == "hello, dear s"
-        @test yguide(plot(args...;kwargs..., surround=(", dear "," esq."))) == "hello, dear s esq."
-        @test yguide(plot(args...;kwargs..., surround=("well ",", dear "," esq."))) == "well hello, dear s esq."
-        @test yguide(plot(args...;kwargs..., surround='?')) == "hello ? s"
-        @test yguide(plot(args...;kwargs..., surround=('<','>'))) == "hello <s>"
-        @test yguide(plot(args...;kwargs..., surround=('A','B','C'))) == "Ahello BsC"
-        @test yguide(plot(args...;kwargs..., surround=false)) == "hello s"
-        @test yguide(plot(args...;kwargs..., surround=true)) == "hello (s)"
-        @test yguide(plot(args...;kwargs..., surround=:round)) == "hello (s)"
-        @test yguide(plot(args...;kwargs..., surround=:square)) == "hello [s]"
-        @test yguide(plot(args...;kwargs..., surround=:curly)) == "hello {s}"
-        @test yguide(plot(args...;kwargs..., surround=:angle)) == "hello <s>"
-        @test yguide(plot(args...;kwargs..., surround=:slash)) == "hello / s"
-        @test yguide(plot(args...;kwargs..., surround=:slashround)) == "hello / (s)"
-        @test yguide(plot(args...;kwargs..., surround=:slashsquare)) == "hello / [s]"
-        @test yguide(plot(args...;kwargs..., surround=:slashcurly)) == "hello / {s}"
-        @test yguide(plot(args...;kwargs..., surround=:slashangle)) == "hello / <s>"
-        @test yguide(plot(args...;kwargs..., surround=:verbose)) == "hello in units of s"
+        args = (x, y)
+        kwargs = (:xlabel=>"hello", :ylabel=>"hello")
+        @test yguide(plot(args...; kwargs..., surround=nothing)) == "hello s"
+        @test yguide(plot(args...; kwargs..., surround=(l, u) -> string(u, " is the unit of ", l))) == "s is the unit of hello"
+        @test yguide(plot(args...; kwargs..., surround=", dear ")) == "hello, dear s"
+        @test yguide(plot(args...; kwargs..., surround=(", dear ", " esq."))) == "hello, dear s esq."
+        @test yguide(plot(args...; kwargs..., surround=("well ", ", dear ", " esq."))) == "well hello, dear s esq."
+        @test yguide(plot(args...; kwargs..., surround='?')) == "hello ? s"
+        @test yguide(plot(args...; kwargs..., surround=('<', '>'))) == "hello <s>"
+        @test yguide(plot(args...; kwargs..., surround=('A', 'B', 'C'))) == "Ahello BsC"
+        @test yguide(plot(args...; kwargs..., surround=false)) == "hello s"
+        @test yguide(plot(args...; kwargs..., surround=true)) == "hello (s)"
+        @test yguide(plot(args...; kwargs..., surround=:round)) == "hello (s)"
+        @test yguide(plot(args...; kwargs..., surround=:square)) == "hello [s]"
+        @test yguide(plot(args...; kwargs..., surround=:curly)) == "hello {s}"
+        @test yguide(plot(args...; kwargs..., surround=:angle)) == "hello <s>"
+        @test yguide(plot(args...; kwargs..., surround=:slash)) == "hello / s"
+        @test yguide(plot(args...; kwargs..., surround=:slashround)) == "hello / (s)"
+        @test yguide(plot(args...; kwargs..., surround=:slashsquare)) == "hello / [s]"
+        @test yguide(plot(args...; kwargs..., surround=:slashcurly)) == "hello / {s}"
+        @test yguide(plot(args...; kwargs..., surround=:slashangle)) == "hello / <s>"
+        @test yguide(plot(args...; kwargs..., surround=:verbose)) == "hello in units of s"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,29 +67,29 @@ end
         @test yguide(plot(x, y, xlabel=P"hello", ylabel=P"hello")) == "hello"
     end
 
-    @testset "surround" begin
+    @testset "unitformat" begin
         args = (x, y)
         kwargs = (:xlabel=>"hello", :ylabel=>"hello")
-        @test yguide(plot(args...; kwargs..., surround=nothing)) == "hello s"
-        @test yguide(plot(args...; kwargs..., surround=(l, u) -> string(u, " is the unit of ", l))) == "s is the unit of hello"
-        @test yguide(plot(args...; kwargs..., surround=", dear ")) == "hello, dear s"
-        @test yguide(plot(args...; kwargs..., surround=(", dear ", " esq."))) == "hello, dear s esq."
-        @test yguide(plot(args...; kwargs..., surround=("well ", ", dear ", " esq."))) == "well hello, dear s esq."
-        @test yguide(plot(args...; kwargs..., surround='?')) == "hello ? s"
-        @test yguide(plot(args...; kwargs..., surround=('<', '>'))) == "hello <s>"
-        @test yguide(plot(args...; kwargs..., surround=('A', 'B', 'C'))) == "Ahello BsC"
-        @test yguide(plot(args...; kwargs..., surround=false)) == "hello s"
-        @test yguide(plot(args...; kwargs..., surround=true)) == "hello (s)"
-        @test yguide(plot(args...; kwargs..., surround=:round)) == "hello (s)"
-        @test yguide(plot(args...; kwargs..., surround=:square)) == "hello [s]"
-        @test yguide(plot(args...; kwargs..., surround=:curly)) == "hello {s}"
-        @test yguide(plot(args...; kwargs..., surround=:angle)) == "hello <s>"
-        @test yguide(plot(args...; kwargs..., surround=:slash)) == "hello / s"
-        @test yguide(plot(args...; kwargs..., surround=:slashround)) == "hello / (s)"
-        @test yguide(plot(args...; kwargs..., surround=:slashsquare)) == "hello / [s]"
-        @test yguide(plot(args...; kwargs..., surround=:slashcurly)) == "hello / {s}"
-        @test yguide(plot(args...; kwargs..., surround=:slashangle)) == "hello / <s>"
-        @test yguide(plot(args...; kwargs..., surround=:verbose)) == "hello in units of s"
+        @test yguide(plot(args...; kwargs..., unitformat=nothing)) == "hello s"
+        @test yguide(plot(args...; kwargs..., unitformat=(l, u) -> string(u, " is the unit of ", l))) == "s is the unit of hello"
+        @test yguide(plot(args...; kwargs..., unitformat=", dear ")) == "hello, dear s"
+        @test yguide(plot(args...; kwargs..., unitformat=(", dear ", " esq."))) == "hello, dear s esq."
+        @test yguide(plot(args...; kwargs..., unitformat=("well ", ", dear ", " esq."))) == "well hello, dear s esq."
+        @test yguide(plot(args...; kwargs..., unitformat='?')) == "hello ? s"
+        @test yguide(plot(args...; kwargs..., unitformat=('<', '>'))) == "hello <s>"
+        @test yguide(plot(args...; kwargs..., unitformat=('A', 'B', 'C'))) == "Ahello BsC"
+        @test yguide(plot(args...; kwargs..., unitformat=false)) == "hello s"
+        @test yguide(plot(args...; kwargs..., unitformat=true)) == "hello (s)"
+        @test yguide(plot(args...; kwargs..., unitformat=:round)) == "hello (s)"
+        @test yguide(plot(args...; kwargs..., unitformat=:square)) == "hello [s]"
+        @test yguide(plot(args...; kwargs..., unitformat=:curly)) == "hello {s}"
+        @test yguide(plot(args...; kwargs..., unitformat=:angle)) == "hello <s>"
+        @test yguide(plot(args...; kwargs..., unitformat=:slash)) == "hello / s"
+        @test yguide(plot(args...; kwargs..., unitformat=:slashround)) == "hello / (s)"
+        @test yguide(plot(args...; kwargs..., unitformat=:slashsquare)) == "hello / [s]"
+        @test yguide(plot(args...; kwargs..., unitformat=:slashcurly)) == "hello / {s}"
+        @test yguide(plot(args...; kwargs..., unitformat=:slashangle)) == "hello / <s>"
+        @test yguide(plot(args...; kwargs..., unitformat=:verbose)) == "hello in units of s"
     end
 end
 


### PR DESCRIPTION
closes #33 

Allows a keyword argument `surround`, which gives near-perfect control of the label formatting. 

```julia
plot(x,y,xlabel="Length",surround=:slash)
```
gives label `"Length / m"`. `surround` can be a number of symbols like this, a tuple of delimeters, or a function that transforms two arguments `(label, unit)` into a string. 