### PR TITLE
Nolabeloverride

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -29,6 +29,8 @@ function fixaxis!(attr, x, axisletter)
         if label isa UnitfulString
             u = label.unit
         end
+        # If label was not given as an argument, reuse
+        get!(attr, axislabel, label)
     end
     # Fix the attributes: labels, lims, marker/line stuff, etc.
     append_unit_if_needed!(attr, axislabel, u)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,9 @@ zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[
         @test yguide(plot(y, ylabel="hello")) == "hello (m)"
         @test yguide(plot(y, ylabel=P"hello")) == "hello"
         @test yguide(plot(y, ylabel="")) == ""
+        pl = plot(y; ylabel="hello")
+        plot!(pl, -y)
+        @test yguide(pl) == "hello (m)"
     end
 
     @testset "yunit" begin


### PR DESCRIPTION
Without this PR,
```julia
y = (1:10)u"m"
plot(y; yguide="y")
plot!(-y)
```
would have the `yguide` `m`, because the `plot!` call would only check if `yguide` was given as an argument, so you would need to make sure to set the label in your last plot call. This is in contrast to how unitless labels and most other keywords work.

With this PR,
```julia
y = (1:10)u"m"
plot(y; yguide="y")
plot!(-y)
```
has `yguide` `y (m)`.