### PR TITLE
Plot function against unit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -150,3 +150,16 @@ x = (1.0:0.1:10) * GeV/c
 y = @. (2 + sin(x / (GeV/c))) * 0.4GeV/c^2 # a sine to make it pretty
 yerror = 10.9MeV/c^2 * exp.(randn(length(x))) # some noise for pretty again
 plot(x, y; yerror, title="My unitful data with yerror bars", lab="")
+
+# ## Functions
+#
+# In order to plot a unitful function on a unitful axis, supply as a second argument a
+# vector of unitful sample points, or the unit for the independent axis:
+
+model(x) = 1u"V"*exp(-((x-0.5u"s")/0.7u"s")^2)
+t = randn(10)u"s" # Sample points
+U = model.(t) + randn(10)u"dV" .|> u"V" # Noisy acquicisions
+plot(t, U; xlabel="t", ylabel="U", st=:scatter, label="Samples")
+plot!(model, t; st=:scatter, label="Noise removed")
+plot!(model, u"s"; label="True function")
+

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -76,10 +76,29 @@ end
     x, y, f.(x',y)
 end
 @recipe function f(f::Function, u::Units)
-    recipedata = RecipesBase.apply_recipe(plotattributes,f)
-    (f, xmin, xmax) = recipedata[1].args
-    f, xmin*u, xmax*u
+    uf = UnitFunction(f, [u])
+    recipedata = RecipesBase.apply_recipe(plotattributes, uf)
+    (_, xmin, xmax) = recipedata[1].args
+    return f, xmin*u, xmax*u
 end
+
+"""
+```julia
+UnitFunction
+```
+A function, bundled with the assumed units of each of its inputs.
+
+```julia
+f(x, y) = x^2 + y
+uf = UnitFunction(f, u"m", u"m^2")
+uf(3, 2) == f(3u"m", 2u"m"^2) == 7u"m^2"
+```
+"""
+struct UnitFunction <: Function
+    f::Function
+    u::Vector{Units}
+end
+(f::UnitFunction)(args...) = f.f((args .* f.u)...)
 
 #===============
 Attribute fixing

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -1,7 +1,7 @@
 module UnitfulRecipes
 
 using RecipesBase
-using Unitful: Quantity, unit, ustrip, Unitful, dimension
+using Unitful: Quantity, unit, ustrip, Unitful, dimension, Units
 export @P_str
 
 #==========
@@ -62,6 +62,9 @@ end
 # Recipes for functions
 @recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
+end
+@recipe function f(f::Function, u::Units)
+    x->f(x*u)
 end
 @recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -75,25 +75,11 @@ end
 @recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
     x, y, f.(x',y)
 end
-@recipe function f(f::Function, u1::Units, u::Vararg{Units})
-    UnitFunction(f, [u1, u...])
+@recipe function f(f::Function, u::Units)
+    recipedata = RecipesBase.apply_recipe(plotattributes,f)
+    (f, xmin, xmax) = recipedata[1].args
+    f, xmin*u, xmax*u
 end
-
-"""
-```julia
-UnitFunction
-```
-A function, bundled with the assumed units of each of its inputs.
-
-```julia
-UnitFunction((x, y)->x^2 + y, u"s", u"m^2")(2,3) == (2u"m")^2 + 3u"m^2" == 7u"m^2"
-```
-"""
-struct UnitFunction <: Function
-    f::Function
-    u::Vector{Units}
-end
-(f::UnitFunction)(args...) = f.f((args .* f.u)...)
 
 #===============
 Attribute fixing

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -63,9 +63,6 @@ end
 @recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
-@recipe function f(f::Function, u::Units)
-    x->f(x*u)
-end
 @recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)
 end
@@ -78,7 +75,25 @@ end
 @recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
     x, y, f.(x',y)
 end
+@recipe function f(f::Function, u1::Units, u::Vararg{Units})
+    UnitFunction(f, [u1, u...])
+end
 
+"""
+```julia
+UnitFunction
+```
+A function, bundled with the assumed units of each of its inputs.
+
+```julia
+UnitFunction((x, y)->x^2 + y, u"s", u"m^2")(2,3) == (2u"m")^2 + 3u"m^2" == 7u"m^2"
+```
+"""
+struct UnitFunction <: Function
+    f::Function
+    u::Vector{Units}
+end
+(f::UnitFunction)(args...) = f.f((args .* f.u)...)
 
 #===============
 Attribute fixing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,6 +114,15 @@ end
         g(x,y) = x*y*m # If the unit comes from the function only then it throws
         @test_throws DimensionError plot(x, y, g) isa Plots.Plot
     end
+    @testset "plot(f, u)" begin
+        f(x) = x^2
+        pl = plot(x*m, f.(x*m))
+        @test plot!(pl, f, m) isa Plots.Plot
+        @test_throws DimensionError plot!(pl, f, s) isa Plots.Plot
+        pl = plot(f, m)
+        @test xguide(pl) == "m"
+        @test yguide(pl) == "m^2"
+    end
 end
 
 @testset "Moar plots" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,8 @@ end
         pl = plot(f, m)
         @test xguide(pl) == string(m)
         @test yguide(pl) == string(m^2)
+        f(x) = exp(x/(3m))
+        @test plot(f, u"m") isa Plots.Plot
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -120,8 +120,8 @@ end
         @test plot!(pl, f, m) isa Plots.Plot
         @test_throws DimensionError plot!(pl, f, s) isa Plots.Plot
         pl = plot(f, m)
-        @test xguide(pl) == "m"
-        @test yguide(pl) == "m^2"
+        @test xguide(pl) == string(m)
+        @test yguide(pl) == string(m^2)
     end
 end
 


### PR DESCRIPTION
I looked into the possibility of making function plots (`plot(f)`) work automatically, but since we don't (and can't) set the limits to unitful quantities, I think that's not going to happen.

To me, the second best thing is being able to plot a function against all of the `x` axis, while *supplying* the unit of the `x` axis. Heuristically, "plot this function against 'seconds'". This is easier than figuring out how to modify a function so that it works in a unitful plot (actually just `plot(x->f(x*u))`, but that always takes me a while to wrap my head around).

```julia
model(x) = 1u"V"*exp(-((x-0.5u"s")/0.7u"s")^2)
t = randn(10)u"s" # Sample points
U = model.(t) + randn(10)u"dV" .|> u"V" # Noisy acquicisions
plot(t, U; xlabel="t", ylabel="U", st=:scatter, label="Samples")
plot!(model, t; st=:scatter, label="Noise removed")
plot!(model, u"s"; label="True function")
```
![image](https://user-images.githubusercontent.com/6677110/112628897-da303200-8e33-11eb-9a91-301562ac789a.png)

Also documents the existing `plot(f, x)`.


Theoretically, we could use any unoccupied signature and use the axis unit parameter, but I couldn't really think of a simpler signature than this. 
Maybe it should ignore the *value* of the unit argument, as it stands `f(model, u"ms")` doesn't make any sense (the `x` axis will be off by a factor 1e3), and `f(model, u"kg")` will straight up fail, so you're not really communicating anything more than that you're expecting a unitful axis anyway.