### PR TITLE
Support units in clim (colorbar limits)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 .DS_Store
 Manifest.toml
 dev/
-.*.*.swp
 
 # for docs
 docs/Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 Manifest.toml
 dev/
+.*.*.swp
 
 # for docs
 docs/Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.3.0"
+version = "1.4.0"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -111,15 +111,17 @@ plot(x, y)
 x, y = [rand(10), rand(15), rand(20)]*u"m", [rand(10), rand(15), rand(20)]*u"g"
 plot(x, y)
 
-# ## 3D and heatmaps
+# ## 3D
 
-# It works in 3D and for heatmaps
+# It works in 3D
 
 x, y = rand(10)*u"km", rand(10)*u"hr"
 z = x ./ y
 plot(x, y, z)
 
-# and colorbar limits can have units
+# ## Heatmaps
+
+# For which colorbar limits (`clims`) can have units
 
 heatmap((1:5)u"μs", 1:4, rand(5,4)u"m", clims=(0u"m", 2u"m"))
 
@@ -142,7 +144,7 @@ x, y = (1:0.01:2)*u"m", (1:0.02:2)*u"s"
 z = x' ./ y
 contour(x, y, z)
 
-# and filled contours, again with optional clims units
+# and filled contours, again with optional `clims` units
 
 contourf(x, y, z, clims=(0u"m/s", 3u"m/s"))
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -133,6 +133,7 @@ scatter(x, y, zcolor=z, clims=(5,20).*unit(eltype(z)))
 
 scatter(x, y, z, zcolor=z)
 
+
 # ## Contour plots
 
 # for contours plots
@@ -141,9 +142,10 @@ x, y = (1:0.01:2)*u"m", (1:0.02:2)*u"s"
 z = x' ./ y
 contour(x, y, z)
 
-# and filled contours
+# and filled contours, again with optional clims units
 
-contourf(x, y, z)
+contourf(x, y, z, clims=(0u"m/s", 3u"m/s"))
+
 
 # ## Error bars
 

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -106,18 +106,22 @@ plot(x, y, ylims=(-1,2), xticks=1:3:length(x))
 x, y = rand(10,3)*u"m", rand(10,3)*u"g"
 plot(x, y)
 
-# Or vectors of vectors (of potnetially different lengths)
+# Or vectors of vectors (of potentially different lengths)
 
 x, y = [rand(10), rand(15), rand(20)]*u"m", [rand(10), rand(15), rand(20)]*u"g"
 plot(x, y)
 
-# ## 3D
+# ## 3D and heatmaps
 
-# It works in 3D
+# It works in 3D and for heatmaps
 
 x, y = rand(10)*u"km", rand(10)*u"hr"
 z = x ./ y
 plot(x, y, z)
+
+# and colorbar limits can have units
+
+heatmap((1:5)u"μs", 1:4, rand(5,4)u"m", clims=(0u"m", 2u"m"))
 
 # ## Scatter plots
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -50,9 +50,19 @@ const AVec = AbstractVector
 const AMat{T} = AbstractArray{T,2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
+    ustripattribute!(plotattributes, :clims, u)
     z = fixaxis!(plotattributes, z, :z)
     append_unit_if_needed!(plotattributes, :colorbar_title, u)
     x, y, z
+end
+
+# Recipe for (z::Surface) types
+@recipe function f(z::AMat{T}) where T <: Quantity
+    u = get(plotattributes, :zunit, unit(eltype(z)))
+    ustripattribute!(plotattributes, :clims, u)
+    z = fixaxis!(plotattributes, z, :z)
+    append_unit_if_needed!(plotattributes, :colorbar_title, u)
+    z
 end
 
 # Recipe for vectors of vectors

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -56,11 +56,12 @@ const AMat{T} = AbstractArray{T,2} where T
     x, y, z
 end
 
-# Recipe for heatmap(z), surface(z)
+# Recipe for contour|heatmap|surface(z)
 # Caution: also gets use for plot(z::Matrix)
 @recipe function f(z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
-    if get(plotattributes, :seriestype, :nothing) ∈ (:heatmap, :surface)
+    clims_types = (:contour, :contourf, :heatmap, :surface)
+    if get(plotattributes, :seriestype, :nothing) ∈ clims_types
         ustripattribute!(plotattributes, :clims, u)
         z = fixaxis!(plotattributes, z, :z)
         append_unit_if_needed!(plotattributes, :colorbar_title, u)

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -64,24 +64,6 @@ const AMat{T} = AbstractArray{T,2} where T
     x, y, z
 end
 
-#=
-# Recipe for contour|heatmap|surface(z)
-# Caution: also gets use for plot(z::Matrix)
-@recipe function f(z::AMat{T}) where T <: Quantity
-    u = get(plotattributes, :zunit, unit(eltype(z)))
-    clims_types = (:contour, :contourf, :heatmap, :surface)
-    if get(plotattributes, :seriestype, :nothing) ∈ clims_types
-        ustripattribute!(plotattributes, :clims, u)
-        z = fixaxis!(plotattributes, z, :z)
-        append_unit_if_needed!(plotattributes, :colorbar_title, u)
-    else # plot(z::Matrix)
-        z = fixaxis!(plotattributes, z, :y)
-        append_unit_if_needed!(plotattributes, :y, u)
-    end
-    z
-end
-=#
-
 # Recipe for vectors of vectors
 @recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
     axisletter = plotattributes[:letter]   # x, y, or z

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -56,17 +56,20 @@ const AMat{T} = AbstractArray{T,2} where T
     x, y, z
 end
 
-#=
-# This code fixes the heatmap(z) issue #59 but breaks some "Moar" tests
-# Recipe for (z::Surface) types
+# Recipe for heatmap(z), surface(z)
+# Caution: also gets use for plot(z::Matrix)
 @recipe function f(z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
-    ustripattribute!(plotattributes, :clims, u)
-    z = fixaxis!(plotattributes, z, :z)
-    append_unit_if_needed!(plotattributes, :colorbar_title, u)
+    if get(plotattributes, :seriestype, :nothing) ∈ (:heatmap, :surface)
+        ustripattribute!(plotattributes, :clims, u)
+        z = fixaxis!(plotattributes, z, :z)
+        append_unit_if_needed!(plotattributes, :colorbar_title, u)
+    else # plot(z::Matrix)
+        z = fixaxis!(plotattributes, z, :y)
+        append_unit_if_needed!(plotattributes, :y, u)
+    end
     z
 end
-=#
 
 # Recipe for vectors of vectors
 @recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -4,12 +4,20 @@ using RecipesBase
 using Unitful: Quantity, unit, ustrip, Unitful, dimension, Units
 export @P_str
 
+const clims_types = (:contour, :contourf, :heatmap, :surface)
+
 #==========
 Main recipe
 ==========#
 
 @recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
     axisletter = plotattributes[:letter]   # x, y, or z
+    if (axisletter == :z) &&
+        get(plotattributes, :seriestype, :nothing) ∈ clims_types
+        u = get(plotattributes, :zunit, unit(eltype(x)))
+        ustripattribute!(plotattributes, :clims, u)
+        append_unit_if_needed!(plotattributes, :colorbar_title, u)
+    end
     fixaxis!(plotattributes, x, axisletter)
 end
 
@@ -56,6 +64,7 @@ const AMat{T} = AbstractArray{T,2} where T
     x, y, z
 end
 
+#=
 # Recipe for contour|heatmap|surface(z)
 # Caution: also gets use for plot(z::Matrix)
 @recipe function f(z::AMat{T}) where T <: Quantity
@@ -71,6 +80,7 @@ end
     end
     z
 end
+=#
 
 # Recipe for vectors of vectors
 @recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -56,6 +56,8 @@ const AMat{T} = AbstractArray{T,2} where T
     x, y, z
 end
 
+#=
+# This code fixes the heatmap(z) issue #59 but breaks some "Moar" tests
 # Recipe for (z::Surface) types
 @recipe function f(z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
@@ -64,6 +66,7 @@ end
     append_unit_if_needed!(plotattributes, :colorbar_title, u)
     z
 end
+=#
 
 # Recipe for vectors of vectors
 @recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,12 @@ xseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[
 yseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:y]
 zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:z]
 
+@testset "heatmap" begin
+   x = (1:3)m
+   @test_broken heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot # todo
+   @test heatmap(1:3, (1:3)*m, x*x', clims=(1m^2,3m^2)) isa Plots.Plot
+end
+
 @testset "plot(y)" begin
     y = rand(3)m
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,16 @@ xseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[
 yseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:y]
 zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[:z]
 
+macro isplot(ex) # @isplot macro to streamline tests
+    :(@test $(esc(ex)) isa Plots.Plot)
+end
+
 @testset "heatmap" begin
    x = (1:3)m
-   @test heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot
-   @test heatmap(1:3, (1:3)*m, x*x', clims=(1m^2,3m^2)) isa Plots.Plot
+   @isplot heatmap(x*x', clims=(1, 7)) # unitless
+   @isplot heatmap(x*x', clims=(2m^2, 8m^2)) # units
+   @isplot heatmap(x*x', clims=(3e6u"μm^2", 7e-6u"km^2")) # conversion
+   @isplot heatmap(1:3, (1:3)m, x*x', clims=(1m^2, 7e-6u"km^2")) # mixed
 end
 
 @testset "plot(y)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[
 
 @testset "heatmap" begin
    x = (1:3)m
-   @test_broken heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot # todo
+   @test heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot # todo
    @test heatmap(1:3, (1:3)*m, x*x', clims=(1m^2,3m^2)) isa Plots.Plot
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,7 +133,7 @@ end
     end
 end
 
-@testset "Moar plots" begin
+@testset "More plots" begin
     @testset "data as $dtype" for dtype in [:Vectors, :Matrices, Symbol("Vectors of vectors")]
         if dtype == :Vectors
             x, y, z = randn(10), randn(10), randn(10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ zseries(plt, idx=length(plt.series_list)) = plt.series_list[idx].plotattributes[
 
 @testset "heatmap" begin
    x = (1:3)m
-   @test heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot # todo
+   @test heatmap(x*x', clims=(1m^2,2m^2)) isa Plots.Plot
    @test heatmap(1:3, (1:3)*m, x*x', clims=(1m^2,3m^2)) isa Plots.Plot
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ end
    x = (1:3)m
    @isplot heatmap(x*x', clims=(1, 7)) # unitless
    @isplot heatmap(x*x', clims=(2m^2, 8m^2)) # units
-   @isplot heatmap(x*x', clims=(3e6u"μm^2", 7e-6u"km^2")) # conversion
+   @isplot heatmap(x*x', clims=(2e6u"mm^2", 7e-6u"km^2")) # conversion
    @isplot heatmap(1:3, (1:3)m, x*x', clims=(1m^2, 7e-6u"km^2")) # mixed
 end
 


### PR DESCRIPTION
This addresses #57 and #58.

Please check carefully my work on #58 because it was tricky to me.
It seems that `plot(rand(5,4))` and `heatmap(rand(5,4))` both have Matrix arguments.  So I suspect that we need may need separate recipes for plot and for heatmap/surface/others? but I don't know enough about recipes to be confident in my solution.