### PR TITLE
Fix adding unit from empty plot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: 100

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -31,7 +31,7 @@ function fixaxis!(attr, x, axisletter)
     axis = Symbol(axisletter, :axis)       # xaxis, yaxis, zaxis
     # Get the unit
     u = pop!(attr, axisunit, unit(eltype(x)))
-    # If the subplot already exists, get unit from its axis label
+    # If the subplot already exists with data, get its unit
     sp = get(attr, :subplot, 1)
     if sp ≤ length(attr[:plot_object]) && attr[:plot_object].n > 0
         label = attr[:plot_object][sp][axis][:guide]

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -33,7 +33,7 @@ function fixaxis!(attr, x, axisletter)
     u = pop!(attr, axisunit, unit(eltype(x)))
     # If the subplot already exists, get unit from its axis label
     sp = get(attr, :subplot, 1)
-    if sp ≤ length(attr[:plot_object])
+    if sp ≤ length(attr[:plot_object]) && attr[:plot_object].n > 0
         label = attr[:plot_object][sp][axis][:guide]
         if label isa UnitfulString
             u = label.unit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -263,3 +263,10 @@ end
     @test xguide(plt) == "mm"
     @test yguide(plt) == "s"
 end
+
+# https://github.com/jw3126/UnitfulRecipes.jl/issues/60
+@testset "Start with empty plot" begin
+    plt = plot()
+    plot!(plt, (1:3)m)
+    @test yguide(plt) == "m"
+end


### PR DESCRIPTION
Fixes #60?

I *think* I fixed it by changing "use the existing label if the subplot already exists" to "use the existing label if the subplot already exists AND at least one series already exists inside of it".

Will let the docs deploy and check what it looks like :) 

