### PR TITLE
Fix doc warnings during CI?

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: 100

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"


### PR DESCRIPTION
This is a docs PR. It essentially does 2 things:
- bumps documenter version
- lets GR know there is no screen output via an environment variable (see https://discourse.julialang.org/t/generation-of-documentation-fails-qt-qpa-xcb-could-not-connect-to-display/60988), which removes many of the display warnings ~and speeds up the docs build significantly~ [*EDIT*: not sure about that one]