### PR TITLE
Bare units recipe

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/1_Examples.jl
+++ b/docs/lit/examples/1_Examples.jl
@@ -172,3 +172,10 @@ plot(t, U; xlabel="t", ylabel="U", st=:scatter, label="Samples")
 plot!(model, t; st=:scatter, label="Noise removed")
 plot!(model, u"s"; label="True function")
 
+# ## Initializing empty plot
+#
+# A plot can be initialized with unitful axes but without datapoints by
+# simply supplying the unit:
+
+plot(u"m", u"s")
+plot!([2u"ft"], [1u"minute"], st=:scatter)

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -70,6 +70,12 @@ end
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
 
+# Recipe for bare units
+@recipe function f(::Type{T}, x::T) where T <: Units
+    primary := false
+    Float64[]*x
+end
+
 # Recipes for functions
 @recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
     x, f.(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,8 +134,8 @@ end
         pl = plot(f, m)
         @test xguide(pl) == string(m)
         @test yguide(pl) == string(m^2)
-        f(x) = exp(x/(3m))
-        @test plot(f, u"m") isa Plots.Plot
+        g(x) = exp(x/(3m))
+        @test plot(g, u"m") isa Plots.Plot
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -236,6 +236,15 @@ end
     @test_throws DimensionError plot!(plt, x3) # can't place seconds on top of meters!
 end
 
+@testset "Bare units" begin
+    plt = plot(u"m", u"s")
+    @test xguide(plt) == "m"
+    @test yguide(plt) == "s"
+    @test iszero(length(plt.series_list[1].plotattributes[:y]))
+    hline!(plt, [1u"hr"])
+    @test yguide(plt) == "s"
+end
+
 @testset "Inset subplots" begin
     x1 = rand(10) * u"m"
     x2 = rand(10) * u"s"


### PR DESCRIPTION
Allows an empty plot to be initialized with axis units by way of `plot(u"m", u"ft")`. 

Closes  #54 