### PR TITLE
added fillrange

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnitfulRecipes"
 uuid = "42071c24-d89e-48dd-8a24-8a12d9b8861f"
 authors = ["Benoit Pasquier", "Jan Weidner"]
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"

--- a/docs/lit/examples/2_Plots.jl
+++ b/docs/lit/examples/2_Plots.jl
@@ -9,7 +9,7 @@
 #md #     These examples are available as Jupyter notebooks.
 #md #     You can execute them online with [binder](https://mybinder.org/) or just view them with [nbviewer](https://nbviewer.jupyter.org/) by clicking on the badges above!
 
-# These examples were slightly modified from some of [the GR examples in the Plots.jl documentation](http://docs.juliaplots.org/latest/examples/gr/) and can be used as both a tutorial or as a series of test for the UnitfulRecipes package
+# These examples were slightly modified from some of [the examples in the Plots.jl documentation](https://github.com/JuliaPlots/Plots.jl/blob/master/src/examples.jl) and can be used as both a tutorial or as a series of test for the UnitfulRecipes package
 # (they are essentially the same except we have added some units to the data).
 
 # First we need to tell Julia we are using Plots, Unitful, and UnitfulRecipes
@@ -74,6 +74,35 @@ styles = reshape(styles, 1, length(styles))
 n = length(styles)
 y = cumsum(randn(20, n), dims=1) * u"km"
 plot(y, line=(5, styles), label=map(string, styles), legendtitle="linestyle")
+
+
+# ## Ribbons
+#
+# Ribbons can be added to lines via the `ribbon` keyword;
+# you can pass:
+#* a single Array (for symmetric ribbons)
+#* a Function
+#* or a number.
+#Currently unsupported: a tuple of arrays (upper and lower bounds)
+#
+x = y = (0:10)*u"m"
+plot(
+    #plot((0:10)*u"m"; ribbon = (LinRange(0, 2, 11)*u"m", LinRange(0, 1, 11)*u"m")),
+    plot(x,y; ribbon = (0:0.5:5)*u"m", label = "Vector"),
+    plot(x,y; ribbon = sqrt, label = "Function"),
+    plot(x,y; ribbon = 1u"m", label = "Constant"), link=:all
+)
+
+# ## Fillrange
+# the fillrange keyword defines a second line and fills between it and the y data. 
+# Note: ribbons are fillranges
+x = y = (0:10)*u"m"
+plot( 
+    plot(x,y; fillrange = (0:0.5:5)*u"m", label = "Vector"),
+    plot(x,y; fillrange = sin, label = "Function"),
+    plot(x,y; fillrange = 0u"m", label = "Constant"), link = :all
+)
+
 
 # ## Marker types
 

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -49,6 +49,9 @@ function fixaxis!(attr, x, axisletter)
     if (axisletter == :y) && haskey(attr, :ribbon)
         ustripattribute!(attr, :ribbon, u)
     end
+    if (axisletter == :y) && haskey(attr, :fillrange)
+        ustripattribute!(attr, :fillrange, u)
+    end
     fixmarkercolor!(attr)
     fixmarkersize!(attr)
     fixlinecolor!(attr)

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -46,10 +46,8 @@ function fixaxis!(attr, x, axisletter)
     ustripattribute!(attr, axislims, u)
     ustripattribute!(attr, axisticks, u)
     ustripattribute!(attr, err, u)
-    if (axisletter == :y) && haskey(attr, :ribbon)
+    if (axisletter == :y)
         ustripattribute!(attr, :ribbon, u)
-    end
-    if (axisletter == :y) && haskey(attr, :fillrange)
         ustripattribute!(attr, :fillrange, u)
     end
     fixmarkercolor!(attr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -283,6 +283,16 @@ end
     @test yguide(plt) == "s"
 end
 
+@testset "Fillrange" begin
+    x = rand(10) * u"mm"
+    y = rand(10) * u"s"
+    fillrange = rand(10) * u"ms"
+    plt =  plot(x, y, fillrange=fillrange)
+    @test plt isa Plots.Plot
+    @test xguide(plt) == "mm"
+    @test yguide(plt) == "s"
+end
+
 # https://github.com/jw3126/UnitfulRecipes.jl/issues/60
 @testset "Start with empty plot" begin
     plt = plot()


### PR DESCRIPTION
This supports fillrange in the same style as ribbon. fillrange is the lower half of the ribbon. 

There is one syntax which isn't covered:
plot(x, y, ribbon=[(1,5)])
the vector of tuples in this ribbon syntax creates a low bound fillrange and adds the upper bound to the data. but, it isn't caught by the fillrange or ribbon ustripattribute! call.