### PR TITLE
limited support for logarithmic units including dB*m and dB/Hz

### DIFF
--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -56,7 +56,7 @@ function fixaxis!(attr, x, axisletter)
     fixmarkersize!(attr)
     fixlinecolor!(attr)
     # Strip the unit
-    ustrip.(u, x)
+    uwstrip.(u, x)
 end
 
 # Recipe for (x::AVec, y::AVec, z::Surface) types
@@ -141,7 +141,7 @@ function ustripattribute!(attr, key)
     if haskey(attr, key)
         v = attr[key]
         u = fullunit(eltype(v))
-        attr[key] = ustrip.(u, v)
+        attr[key] = uwstrip.(u, v)
         return u
     else
         return Unitful.NoUnits
@@ -152,7 +152,7 @@ function ustripattribute!(attr, key, u)
     if haskey(attr, key)
         v = attr[key]
         if eltype(v) <: Quantity
-            attr[key] = ustrip.(u, v)
+            attr[key] = uwstrip.(u, v)
         end
     end
     u

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -1,8 +1,10 @@
 module UnitfulRecipes
 
 using RecipesBase
-using Unitful: Quantity, unit, ustrip, Unitful, dimension, Units
+using Unitful: Quantity, unit, ustrip, Unitful, dimension, Units, MixedUnits
 export @P_str
+
+include("UnitfulWrapper.jl")
 
 const clims_types = (:contour, :contourf, :heatmap, :surface)
 
@@ -10,11 +12,11 @@ const clims_types = (:contour, :contourf, :heatmap, :surface)
 Main recipe
 ==========#
 
-@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity, <:LogScaled}}
     axisletter = plotattributes[:letter]   # x, y, or z
     if (axisletter == :z) &&
         get(plotattributes, :seriestype, :nothing) ∈ clims_types
-        u = get(plotattributes, :zunit, unit(eltype(x)))
+        u = get(plotattributes, :zunit, fullunit(eltype(x)))
         ustripattribute!(plotattributes, :clims, u)
         append_unit_if_needed!(plotattributes, :colorbar_title, u)
     end
@@ -30,7 +32,7 @@ function fixaxis!(attr, x, axisletter)
     axisunit = Symbol(axisletter, :unit)   # xunit, yunit, zunit
     axis = Symbol(axisletter, :axis)       # xaxis, yaxis, zaxis
     # Get the unit
-    u = pop!(attr, axisunit, unit(eltype(x)))
+    u = pop!(attr, axisunit, fullunit(eltype(x)))
     # If the subplot already exists with data, get its unit
     sp = get(attr, :subplot, 1)
     if sp ≤ length(attr[:plot_object]) && attr[:plot_object].n > 0
@@ -61,7 +63,7 @@ end
 const AVec = AbstractVector
 const AMat{T} = AbstractArray{T,2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
-    u = get(plotattributes, :zunit, unit(eltype(z)))
+    u = get(plotattributes, :zunit, fullunit(eltype(z)))
     ustripattribute!(plotattributes, :clims, u)
     z = fixaxis!(plotattributes, z, :z)
     append_unit_if_needed!(plotattributes, :colorbar_title, u)
@@ -69,34 +71,34 @@ const AMat{T} = AbstractArray{T,2} where T
 end
 
 # Recipe for vectors of vectors
-@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
+@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity, <:LogScaled}}}
     axisletter = plotattributes[:letter]   # x, y, or z
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
 
-# Recipe for bare units
-@recipe function f(::Type{T}, x::T) where T <: Units
+# Recipe for bare Union{Units, MixedUnits}
+@recipe function f(::Type{T}, x::T) where T <: Union{Units, MixedUnits}
     primary := false
     Float64[]*x
 end
 
 # Recipes for functions
-@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity,<:LogScaled}}
     x, f.(x)
 end
-@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity,<:LogScaled}}
     x, f.(x)
 end
-@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity,<:LogScaled}}
     x, y, f.(x',y)
 end
-@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity,<:LogScaled}}
     x, y, f.(x',y)
 end
-@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
+@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity,<:LogScaled}}, T2<:AVec{<:Union{Missing,<:Quantity,<:LogScaled}}}
     x, y, f.(x',y)
 end
-@recipe function f(f::Function, u::Units)
+@recipe function f(f::Function, u::Union{Units, MixedUnits})
     uf = UnitFunction(f, [u])
     recipedata = RecipesBase.apply_recipe(plotattributes, uf)
     (_, xmin, xmax) = recipedata[1].args
@@ -117,7 +119,7 @@ uf(3, 2) == f(3u"m", 2u"m"^2) == 7u"m^2"
 """
 struct UnitFunction <: Function
     f::Function
-    u::Vector{Units}
+    u::Vector{T} where T<: Union{Units, MixedUnits}
 end
 (f::UnitFunction)(args...) = f.f((args .* f.u)...)
 
@@ -138,7 +140,7 @@ fixlinecolor!(attr) = ustripattribute!(attr, :line_z)
 function ustripattribute!(attr, key)
     if haskey(attr, key)
         v = attr[key]
-        u = unit(eltype(v))
+        u = fullunit(eltype(v))
         attr[key] = ustrip.(u, v)
         return u
     else
@@ -198,7 +200,7 @@ end
 Append unit to labels when appropriate
 =====================================#
 
-function append_unit_if_needed!(attr, key, u::Unitful.Units)
+function append_unit_if_needed!(attr, key, u::T) where T<:Union{MixedUnits, Units}
     label = get(attr, key, nothing)
     append_unit_if_needed!(attr, key, label, u)
 end

--- a/src/UnitfulWrapper.jl
+++ b/src/UnitfulWrapper.jl
@@ -1,6 +1,6 @@
 using Unitful: Gain, Level, MixedUnits, LogScaled, NoUnits, uconvert
-import Unitful: ustrip
-export fullunit
+using Unitful: ustrip
+export fullunit, uwstrip
 
 #=====
 Extension to Unitful.jl, required to plot LogScaled units and 
@@ -53,9 +53,9 @@ fullunit(x::Missing) = missing
 
 
 #=====
-ustrip(u, x) for logscaled units
+uwstrip(u, x) placeholder for ustrip
 =====#
 # level
-function ustrip(u::T, x::L) where {T<:MixedUnits, L<:Union{Quantity, LogScaled}} 
-    ustrip(uconvert(u, x))
-end
+uwstrip(u::T, x::L) where {T<:MixedUnits, L<:Union{Quantity, LogScaled}}  = ustrip(uconvert(u, x))
+#all other
+uwstrip(u, x) = ustrip(u, x)

--- a/src/UnitfulWrapper.jl
+++ b/src/UnitfulWrapper.jl
@@ -1,0 +1,61 @@
+using Unitful: Gain, Level, MixedUnits, LogScaled, NoUnits, uconvert
+import Unitful: ustrip
+export fullunit
+
+#=====
+Extension to Unitful.jl, required to plot LogScaled units and 
+Quantities with LogScaled values (dB/Hz).
+
+Intruduces function:
+    fullunit
+
+and adds a new method to ustrip for LogScaled units.
+
+=====#
+
+#=====
+fullunit(x)
+------------
+Define new function fullunit which returns correct unit of Quantity and LogScaled.
+
+Unitful.unit(dB/Hz) == Hz⁻¹
+Unitful.unit(dB) == NoUnits
+Unitful.logunit(dB/Hz) == dB
+
+expected behavior:
+fullunit(dB/Hz) == dB Hz⁻¹
+fullunit(dB) == dB
+fullunit(Hz) == Hz
+=====#
+
+# general argument
+fullunit(x::T) where T<: Quantity = unit(x)
+fullunit(x::Type{T}) where T<:Quantity = unit(x)
+
+# gain
+fullunit(x::Gain{L,S}) where {L,S} = fullunit(eltype(x))
+fullunit(::Type{T}) where {L,S,T<:Gain{L,S}} = MixedUnits{Gain{L,S}}()
+
+# level
+fullunit(x::Level{L,S}) where {L,S} = fullunit(eltype(x))
+fullunit(::Type{T}) where {L,S,T<:Level{L,S}} = MixedUnits{Level{L,S}}()
+
+# quantity with mixed unit
+fullunit(x::Quantity{T,D,U}) where {T<:LogScaled , D , U} = fullunit(eltype(x))
+fullunit(::Type{Quantity{T, D, U}}) where {T<:LogScaled , D , U} = fullunit(T) * U()
+
+# others from Unitful util.jl
+fullunit(x::T) where T<: Number = NoUnits
+fullunit(::Type{T}) where T<:Number= NoUnits
+fullunit(::Type{Union{Missing, T}}) where T = fullunit(T)
+fullunit(::Type{Missing}) = missing
+fullunit(x::Missing) = missing
+
+
+#=====
+ustrip(u, x) for logscaled units
+=====#
+# level
+function ustrip(u::T, x::L) where {T<:MixedUnits, L<:Union{Quantity, LogScaled}} 
+    ustrip(uconvert(u, x))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -331,7 +331,8 @@ end
     x, y, x1, y1 = randn(3)*dB/Hz, randn(3)*dB*m, rand(3)*B/MHz, rand(3)*B*cm
     
     @testset "no keyword argument" begin
-        @test xguide(plot(x,y)) == "dB Hz⁻¹"
+        dbhz = Sys.isapple() ? "dB Hz⁻¹" : "dB Hz^-1"  # expect fancy exponent or not?
+        @test xguide(plot(x,y)) ==  dbhz
         @test xseries(plot(x,y)) ≈ ustrip.(x)
         @test yguide(plot(x,y)) == "dB m"
         @test yseries(plot(x,y)) ≈ ustrip.(y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,3 +344,19 @@ end
     end
 
 end
+
+@testset "fullunit methods test" begin
+    @test @inferred(fullunit(1m^2)) === m^2
+    @test @inferred(fullunit(1dB)) === dB
+    @test @inferred(fullunit(1dBm)) === dBm
+    @test @inferred(fullunit(1dB*m)) === dB*m
+    @test @inferred(fullunit(typeof(1m^2))) === m^2
+    @test @inferred(fullunit(typeof(1dB))) === dB
+    @test @inferred(fullunit(typeof(1dBm))) === dBm
+    @test @inferred(fullunit(typeof(1dB*m))) === dB*m
+    @test @inferred(fullunit(Float64)) === NoUnits
+    @test @inferred(fullunit(Union{typeof(1m^2),Missing})) === m^2
+    @test @inferred(fullunit(Union{Float64,Missing})) === NoUnits
+    @test @inferred(fullunit(missing)) === missing
+    @test @inferred(fullunit(Missing)) === missing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, Unitful, Plots
-using Unitful: m, s, cm, DimensionError
+using Unitful: m, s, cm, mm, DimensionError
 using Unitful: dBm, dB, dBV, V, Hz, B, MHz
 using UnitfulRecipes
 
@@ -359,4 +359,16 @@ end
     @test @inferred(fullunit(Union{Float64,Missing})) === NoUnits
     @test @inferred(fullunit(missing)) === missing
     @test @inferred(fullunit(Missing)) === missing
+end
+
+@testset "uwstrip tests" begin
+     # ustrip with type and unit arguments
+     @test @inferred(uwstrip(m, 3.0m)) === 3.0
+     @test @inferred(uwstrip(m, 2mm)) === 1//500
+     @test @inferred(uwstrip(mm, 3.0m)) === 3000.0
+     @test @inferred(uwstrip(NoUnits, 3.0m/1.0m)) === 3.0
+     @test @inferred(uwstrip(NoUnits, 3.0m/1.0cm)) === 300.0
+     @test @inferred(uwstrip(cm, missing)) === missing
+     @test @inferred(uwstrip(NoUnits, missing)) === missing
+     @test_throws DimensionError uwstrip(NoUnits, 3.0m/1.0s)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Test, Unitful, Plots
 using Unitful: m, s, cm, DimensionError
+using Unitful: dBm, dB, dBV, V, Hz, B, MHz
 using UnitfulRecipes
 
 # Some helper functions to access the subplot labels and the series inside each test plot
@@ -298,4 +299,47 @@ end
     plt = plot()
     plot!(plt, (1:3)m)
     @test yguide(plt) == "m"
+end
+
+@testset "LogScaled plots" begin
+    x, y, dbv, v = randn(3)*dBm, randn(3)*dB, rand(3)*dBV, rand(3)V
+    
+    @testset "no keyword argument" begin
+        @test xguide(plot(x,y)) == "dBm"
+        @test xseries(plot(x,y)) ≈ ustrip.(x)
+        @test yguide(plot(x,y)) == "dB"
+        @test yseries(plot(x,y)) ≈ ustrip.(y)
+        plot(x, dbv)
+        @test yseries(plot!(x, v)) ≈ ustrip(uconvert.(u"dBV", v))
+        plot(x, v)
+        @test yseries(plot!(x, dbv)) ≈ ustrip(uconvert.(u"V", dbv))
+    end
+
+    @testset "labels" begin
+        @test xguide(plot(x, y, xlabel= "hello")) == "hello (dBm)"
+        @test xguide(plot(x, y, xlabel=P"hello")) == "hello"
+        @test yguide(plot(x, y, ylabel= "hello")) == "hello (dB)"
+        @test yguide(plot(x, y, ylabel=P"hello")) == "hello"
+        @test xguide(plot(x, y, xlabel= "hello", ylabel= "hello")) == "hello (dBm)"
+        @test xguide(plot(x, y, xlabel=P"hello", ylabel=P"hello")) == "hello"
+        @test yguide(plot(x, y, xlabel= "hello", ylabel= "hello")) == "hello (dB)"
+        @test yguide(plot(x, y, xlabel=P"hello", ylabel=P"hello")) == "hello"
+    end  
+end
+
+@testset "mixed Log units" begin
+    x, y, x1, y1 = randn(3)*dB/Hz, randn(3)*dB*m, rand(3)*B/MHz, rand(3)*B*cm
+    
+    @testset "no keyword argument" begin
+        @test xguide(plot(x,y)) == "dB Hz⁻¹"
+        @test xseries(plot(x,y)) ≈ ustrip.(x)
+        @test yguide(plot(x,y)) == "dB m"
+        @test yseries(plot(x,y)) ≈ ustrip.(y)
+    end
+    @testset "plot!" begin
+        plot(x, y)
+        @test xseries(plot!(x1, y)) ≈ ustrip(ustrip(uconvert.(u"dB/Hz", x1)))
+        @test yseries(plot!(x1, y1)) ≈ ustrip(ustrip(uconvert.(u"dB*m", y1)))
+    end
+
 end


### PR DESCRIPTION
I hope you don't me starting a new pull request on logarithmic units.
I decided on a new approach to support logarithmic units. This requires minimal changes to the existing code, but adds support for the four identified issues:

1. What happens if you plot `dBV` and then `plot!` `dBμV`? -> works 
3. If you `plot` `dBV`, and then `plot!` `V`? -> works
4. If you plot `V` and then `plot!` `dBV`? -> works
5. Is `dB/m` treated well? -> dB/m, dB/Hz, dB*m are working 

Note: I found that only the `unit` function in Unitful.jl required a fix. See the comments in the UnitfulWrapper.jl file. `unit` produces inconsistent results for logarithmic units. Fixing this within Unitful.jl caused a lot of things to break (a lot of math in Unitful requires unit to behave the way it does). As a temporary fix, I took the liberty of defining a new function `fullunit` which returns an appropriate unit instead.

Finally, Unitful.jl does not have a method `ustrip(unit, quantity)` for logarithmic units. I added one in the UnitfulWrapper.jl.

These changes are sufficient to support logarithmic units.

I will be very grateful if you'd consider merging this PR. Let me know if you have any thoughts or comments on the solution. Improvements are also welcome.