### PR TITLE
Plotting functions with more general arrays

### DIFF
--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -6,11 +6,17 @@ export @P_str
 
 const clims_types = (:contour, :contourf, :heatmap, :surface)
 
+const UMQ = Union{Missing, <:Quantity}
+const AVec = AbstractVector
+const AArr = AbstractArray
+const AArrArrQ = AArr{<:AArr{<:UMQ}}
+const AMat{T} = AArr{T,2} where T
+
 #==========
 Main recipe
 ==========#
 
-@recipe function f(::Type{T}, x::T) where T <: AbstractArray{<:Union{Missing,<:Quantity}}
+@recipe function f(::Type{T}, x::T) where T <: AArr{<:UMQ}
     axisletter = plotattributes[:letter]   # x, y, or z
     if (axisletter == :z) &&
         get(plotattributes, :seriestype, :nothing) ∈ clims_types
@@ -59,10 +65,6 @@ function fixaxis!(attr, x, axisletter)
 end
 
 # Recipe for (x::AVec, y::AVec, z::Surface) types
-const AVec = AbstractVector
-const AArr = AbstractArray
-const AArrArrQ = AbstractArray{<:AbstractArray{<:Union{Missing,<:Quantity}}}
-const AMat{T} = AbstractArray{T,2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
     ustripattribute!(plotattributes, :clims, u)
@@ -72,7 +74,7 @@ const AMat{T} = AbstractArray{T,2} where T
 end
 
 # Recipe for vectors of vectors
-@recipe function f(::Type{T}, x::T) where T <: AbstractVector{<:AbstractVector{<:Union{Missing,<:Quantity}}}
+@recipe function f(::Type{T}, x::T) where T <: AVec{<:AVec{<:UMQ}}
     axisletter = plotattributes[:letter]   # x, y, or z
     [fixaxis!(plotattributes, x, axisletter) for x in x]
 end
@@ -84,19 +86,19 @@ end
 end
 
 # Recipes for functions
-@recipe function f(f::Function, x::T) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(f::Function, x::T) where T <: AArr{<:UMQ}
     x, f.(x)
 end
-@recipe function f(x::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::T, f::Function) where T <: AArr{<:UMQ}
     x, f.(x)
 end
-@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::T, y::AVec, f::Function) where T <: AVec{<:UMQ}
     x, y, f.(x',y)
 end
-@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:Union{Missing,<:Quantity}}
+@recipe function f(x::AVec, y::T, f::Function) where T <: AVec{<:UMQ}
     x, y, f.(x',y)
 end
-@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:Union{Missing,<:Quantity}}, T2<:AVec{<:Union{Missing,<:Quantity}}}
+@recipe function f(x::T1, y::T2, f::Function) where {T1<:AVec{<:UMQ}, T2<:AVec{<:UMQ}}
     x, y, f.(x',y)
 end
 @recipe function f(f::Function, u::Units)

--- a/src/UnitfulRecipes.jl
+++ b/src/UnitfulRecipes.jl
@@ -60,6 +60,8 @@ end
 
 # Recipe for (x::AVec, y::AVec, z::Surface) types
 const AVec = AbstractVector
+const AArr = AbstractArray
+const AArrArrQ = AbstractArray{<:AbstractArray{<:Union{Missing,<:Quantity}}}
 const AMat{T} = AbstractArray{T,2} where T
 @recipe function f(x::AVec, y::AVec, z::AMat{T}) where T <: Quantity
     u = get(plotattributes, :zunit, unit(eltype(z)))
@@ -102,6 +104,25 @@ end
     recipedata = RecipesBase.apply_recipe(plotattributes, uf)
     (_, xmin, xmax) = recipedata[1].args
     return f, xmin*u, xmax*u
+end
+@recipe function f(u::Units, f::Function)
+    return f, u
+end
+#=========================================================================
+If x is an array of arrays of quantities, consider those different series.
+No need to dive deeper than this, a plot of arrays of arrays of arrays is
+not implemented in Plots.
+=========================================================================#
+@recipe function f(f::Function, x::AArrArrQ)
+    for s in x
+        @series begin
+            xunit := unit(first(first(x)))
+            f, s
+        end
+    end
+end
+@recipe function f(x::AArrArrQ, f::Function)
+    return f, x
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,7 +111,7 @@ end
 end
 
 @testset "With functions" begin
-    x, y = randn(3), randn(3)
+    x, y, α = randn(3), randn(3), (1:5)
     @testset "plot(f, x) / plot(x, f)" begin
         f(x) = x^2
         @test plot(  f, x*m) isa Plots.Plot
@@ -119,6 +119,9 @@ end
         g(x) = x*m # If the unit comes from the function only then it throws
         @test_throws DimensionError plot(x, g) isa Plots.Plot
         @test_throws DimensionError plot(g, x) isa Plots.Plot
+        # a matrix of small angles should give positive `sin`s (otherwise they are probably
+        # interpreted as radians)
+        @test all(>(0), yseries(plot(sin, [α*° 2α*°])))
     end
     @testset "plot(x, y, f)" begin
         f(x,y) = x*y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, Unitful, Plots
-using Unitful: m, s, cm, DimensionError
+using Unitful: m, s, cm, °, rad, DimensionError
 using UnitfulRecipes
 
 testfile = "test.png"
@@ -128,12 +128,15 @@ end
         g(x,y) = x*y*m # If the unit comes from the function only then it throws
         @test_throws DimensionError plot(x, y, g) isa Plots.Plot
     end
-    @testset "plot(f, u)" begin
+    @testset "plot(f, u) / plot(u, f)" begin
         f(x) = x^2
         pl = plot(x*m, f.(x*m))
         @test plot!(pl, f, m) isa Plots.Plot
         @test_throws DimensionError plot!(pl, f, s) isa Plots.Plot
         pl = plot(f, m)
+        @test xguide(pl) == string(m)
+        @test yguide(pl) == string(m^2)
+        pl = plot(m, f)
         @test xguide(pl) == string(m)
         @test yguide(pl) == string(m^2)
         g(x) = exp(x/(3m))
@@ -324,9 +327,27 @@ end
                                     ), testfile)
 end
 
-# https://github.com/jw3126/UnitfulRecipes.jl/issues/60
 @testset "Start with empty plot" begin
     plt = plot()
     plot!(plt, (1:3)m)
     @test yguide(plt) == "m"
+end
+
+@testset "Array of arrays" begin
+    α, β = (1:5), (0.1:0.1:0.5)
+    @test yguide(plot(x->x^2, [α*m])) == string(m^2)
+    plt = plot(sin, [α*°])
+    @test xguide(plt) == string(°)
+    # sin(x) > 0 for all x in (1:5)°, but <0 for some x in (1:5)rad
+    @test all(>(0), yseries(plt))
+    plt = plot(sin, [α*°, β*°])
+    @test xguide(plt) == string(°)
+    @test all(>(0), yseries(plt))
+    plt = plot(sin, AbstractArray{Unitful.Quantity}[α*°, β*rad])
+    @test xguide(plt) == string(°)
+    @test all(>(0), yseries(plt))
+    plt = plot(AbstractArray{Unitful.Quantity}[α*°, β*rad], sin)
+    @test xguide(plt) == string(°)
+    @test all(>(0), yseries(plt))
+    @test_throws DimensionError plot(x->x^2, AbstractArray{Unitful.Quantity}[α*m, α*s])
 end


### PR DESCRIPTION
Solves #71. 

Accept unitful AbstractArrays and Vectors of unitful Vectors as the x axis to functions, leading to multiple series.

(Also more consistently abbreviate array types to save text width and increase legibility, and create a `plot(u, f)` recipe to go with the `plot(f, u)` recipe)